### PR TITLE
Update package.json to include npm run qri

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "scripts": {
     "develop": "NODE_ENV=development node server.js",
+    "qri": "qri server -p 3000",
     "test": "jest",
     "build": "NODE_ENV=production webpack --progress --config webpack.config.prod",
     "build:staging": "NOSE_ENV=development webpack --progress --config webpack.config.staging",


### PR DESCRIPTION
Currently we need both `qri server` and `npm run develop` to run the dev environment, this adds `npm run qri` to keep the port numbers matched.