### PR TITLE
Edit and save metadata

### DIFF
--- a/src/js/actions/dataset.js
+++ b/src/js/actions/dataset.js
@@ -6,15 +6,27 @@ import { selectDatasetByAddress } from '../selectors/dataset'
 import { newLocalModel, updateLocalModel, editModel } from './locals'
 import { setMessage, resetMessage, removeModel } from './app'
 
+const blankMetadata = {
+  title: '',
+  description: '',
+  keyword: [],
+  rights: '',
+  landingPage: '',
+  theme: [],
+  identifier: '',
+  accessLevel: '',
+  language: [],
+  license: ''
+}
+
 const DATASET_NEW = 'DATASET_NEW'
-export function newDataset (attributes = {}) {
-  attributes = Object.assign({
+export function newDataset (attributes = {}, dataset = {}) {
+  const datasetRef = Object.assign({
     name: '',
-    source_url: '',
-    summary: '',
-    description: ''
+    path: '',
+    dataset: Object.assign(blankMetadata, dataset)
   }, attributes)
-  return newLocalModel(Schemas.DATASET, DATASET_NEW, attributes)
+  return newLocalModel(Schemas.DATASET, DATASET_NEW, datasetRef)
 }
 
 const DATASET_UPDATE = 'DATASET_UPDATE'

--- a/src/js/actions/dataset.js
+++ b/src/js/actions/dataset.js
@@ -15,7 +15,7 @@ const blankMetadata = {
   theme: [],
   identifier: '',
   accessLevel: '',
-  language: '',
+  language: [],
   license: ''
 }
 

--- a/src/js/actions/dataset.js
+++ b/src/js/actions/dataset.js
@@ -34,6 +34,11 @@ export function updateDataset (dataset) {
   return updateLocalModel(Schemas.DATASET, DATASET_UPDATE, dataset)
 }
 
+const DATASET_CANCEL_EDIT = 'DATASET_CANCEL_EDIT'
+export function cancelDatasetEdit (path) {
+  return removeLocalModel(Schemas.DATASET, DATASET_CANCEL_EDIT, path)
+}
+
 export const DATASETS_REQUEST = 'DATASETS_REQUEST'
 export const DATASETS_SUCCESS = 'DATASETS_SUCCESS'
 export const DATASETS_FAILURE = 'DATASETS_FAILURE'
@@ -156,19 +161,22 @@ export const DATASET_SAVE_REQUEST = 'DATASET_SAVE_REQUEST'
 export const DATASET_SAVE_SUCCESS = 'DATASET_SAVE_SUCCESS'
 export const DATASET_SAVE_FAILURE = 'DATASET_SAVE_FAILURE'
 
-export function saveDataset (dataset) {
-  if (dataset.id === 'new') {
-    return createDataset(dataset)
+export function saveDataset (datasetRef) {
+  if (datasetRef.path === 'new') {
+    return createDataset(datasetRef.dataset)
   }
 
   return (dispatch) => {
     return dispatch({
       [CALL_API]: {
         types: [DATASET_SAVE_REQUEST, DATASET_SAVE_SUCCESS, DATASET_SAVE_FAILURE],
-        endpoint: `/datasets/${dataset.id}`,
+        endpoint: `/datasets/`,
         method: 'PUT',
         schema: Schemas.DATASET,
-        data: dataset
+        data: {
+          prev: datasetRef.path,
+          changes: datasetRef.dataset
+        }
       }
     }).then((action) => {
       if (action.type === DATASET_SAVE_SUCCESS) {

--- a/src/js/actions/dataset.js
+++ b/src/js/actions/dataset.js
@@ -2,7 +2,7 @@ import { push } from 'react-router-redux'
 
 import { CALL_API } from '../middleware/api'
 import Schemas from '../schemas'
-import { selectDatasetByAddress } from '../selectors/dataset'
+import { selectDatasetByPath } from '../selectors/dataset'
 import { newLocalModel, updateLocalModel, editModel } from './locals'
 import { setMessage, resetMessage, removeModel } from './app'
 
@@ -15,7 +15,7 @@ const blankMetadata = {
   theme: [],
   identifier: '',
   accessLevel: '',
-  language: [],
+  language: '',
   license: ''
 }
 
@@ -66,28 +66,28 @@ export const DATASET_REQUEST = 'DATASET_REQUEST'
 export const DATASET_SUCCESS = 'DATASET_SUCCESS'
 export const DATASET_FAILURE = 'DATASET_FAILURE'
 
-export function fetchDataset (address) {
+export function fetchDataset (path) {
   return {
     [CALL_API]: {
       types: [DATASET_REQUEST, DATASET_SUCCESS, DATASET_FAILURE],
-      endpoint: `/datasets?address=${address}`,
+      endpoint: `/datasets${path}`,
       schema: Schemas.DATASET,
-      address
+      path
     }
   }
 }
 
-export function loadDataset (address, requiredFields = []) {
+export function loadDataset (path, requiredFields = []) {
   return (dispatch, getState) => {
-    const dataset = selectDatasetByAddress(getState(), address)
-    if (dataset.schema != null) {
+    const datasetRef = selectDatasetByPath(getState(), path)
+    if (datasetRef.dataset.schema != null) {
       return null
     }
     // if (dataset && requiredFields.every(key => dataset.hasOwnProperty(key))) {
     //   return null
     // }
 
-    return dispatch(fetchDataset(address, requiredFields))
+    return dispatch(fetchDataset(path, requiredFields))
   }
 }
 

--- a/src/js/actions/metadata.js
+++ b/src/js/actions/metadata.js
@@ -1,7 +1,7 @@
 import { CALL_API } from '../middleware/api'
 import Schemas from '../schemas'
 
-import analytics from '../analytics'
+// import analytics from '../analytics'
 import { selectMetadata } from '../selectors/metadata'
 import { newLocalModel, updateLocalModel, editModel, removeLocalModel } from './locals'
 
@@ -80,7 +80,7 @@ export function saveMetadata (metadata = {}) {
   })
 
   return (dispatch) => {
-    analytics.track('Created Metadata', metadata)
+    // analytics.track('Created Metadata', metadata)
     return dispatch({
       [CALL_API]: {
         types: [METADATA_SAVE_REQUEST, METADATA_SAVE_SUCCESS, METADATA_SAVE_FAILURE],

--- a/src/js/actions/metadata.js
+++ b/src/js/actions/metadata.js
@@ -6,23 +6,21 @@ import { selectMetadata } from '../selectors/metadata'
 import { newLocalModel, updateLocalModel, editModel, removeLocalModel } from './locals'
 
 const blankMetadata = {
-  meta: {
-    title: '',
-    description: '',
-    keyword: '',
-    rights: '',
-    landingPage: '',
-    theme: '',
-    identifier: '',
-    accessLevel: 'public',
-    language: 'english',
-    license: 'http://www.usa.gov/publicdomain/label/1.0/'
-  }
+  title: '',
+  description: '',
+  keyword: '',
+  rights: '',
+  landingPage: '',
+  theme: '',
+  identifier: '',
+  accessLevel: '',
+  language: '',
+  license: ''
 }
 
 const METADATA_NEW = 'METADATA_NEW'
-export function newMetadata (keyId, subject) {
-  return newLocalModel(Schemas.METADATA, METADATA_NEW, Object.assign({}, blankMetadata, { keyId, subject }))
+export function newMetadata (metadata, path) {
+  return newLocalModel(Schemas.METADATA, METADATA_NEW, Object.assign({}, blankMetadata, metadata, { path: path }))
 }
 
 const METADATA_EDIT = 'METADATA_EDIT'

--- a/src/js/actions/metadata.js
+++ b/src/js/actions/metadata.js
@@ -1,0 +1,123 @@
+import { CALL_API } from '../middleware/api'
+import Schemas from '../schemas'
+
+import analytics from '../analytics'
+import { selectMetadata } from '../selectors/metadata'
+import { newLocalModel, updateLocalModel, editModel, removeLocalModel } from './locals'
+
+const blankMetadata = {
+  meta: {
+    title: '',
+    description: '',
+    keyword: '',
+    rights: '',
+    landingPage: '',
+    theme: '',
+    identifier: '',
+    accessLevel: 'public',
+    language: 'english',
+    license: 'http://www.usa.gov/publicdomain/label/1.0/'
+  }
+}
+
+const METADATA_NEW = 'METADATA_NEW'
+export function newMetadata (keyId, subject) {
+  return newLocalModel(Schemas.METADATA, METADATA_NEW, Object.assign({}, blankMetadata, { keyId, subject }))
+}
+
+const METADATA_EDIT = 'METADATA_EDIT'
+export function editMetadata (metadata) {
+  return editModel(Schemas.METADATA, METADATA_EDIT, Object.assign({}, blankMetadata, metadata))
+}
+
+const METADATA_CANCEL_EDIT = 'METADATA_CANCEL_EDIT'
+export function cancelMetadataEdit (metadata) {
+  return removeLocalModel(Schemas.METADATA, METADATA_CANCEL_EDIT, metadata)
+}
+
+const METADATA_UPDATE = 'METADATA_UPDATE'
+export function updateMetadata (metadata) {
+  return updateLocalModel(Schemas.METADATA, METADATA_UPDATE, metadata)
+}
+
+export const METADATA_REQUEST = 'METADATA_REQUEST'
+export const METADATA_SUCCESS = 'METADATA_SUCCESS'
+export const METADATA_FAILURE = 'METADATA_FAILURE'
+
+export function fetchMetadata (keyId, subject) {
+  return {
+    [CALL_API]: {
+      types: [METADATA_REQUEST, METADATA_SUCCESS, METADATA_FAILURE],
+      endpoint: `/metadata/${keyId}/${subject}`,
+      schema: Schemas.METADATA,
+      data: { keyId, subject }
+    }
+  }
+}
+
+export function loadMetadata (keyId, subject, requiredFields = []) {
+  return (dispatch, getState) => {
+    const metadata = selectMetadata(getState(), keyId, subject)
+    if (metadata && requiredFields.every(key => Object.prototype.hasOwnProperty.call(metadata, key))) {
+      return null
+    }
+
+    return dispatch(fetchMetadata(keyId, subject, requiredFields))
+  }
+}
+
+export const METADATA_SAVE_REQUEST = 'METADATA_SAVE_REQUEST'
+export const METADATA_SAVE_SUCCESS = 'METADATA_SAVE_SUCCESS'
+export const METADATA_SAVE_FAILURE = 'METADATA_SAVE_FAILURE'
+
+export function saveMetadata (metadata = {}) {
+  // TODO - should this happen here?
+  const md = {}
+  Object.keys(metadata).forEach((key) => {
+    if (metadata[key]) {
+      md[key] = metadata[key]
+    }
+  })
+
+  return (dispatch) => {
+    analytics.track('Created Metadata', metadata)
+    return dispatch({
+      [CALL_API]: {
+        types: [METADATA_SAVE_REQUEST, METADATA_SAVE_SUCCESS, METADATA_SAVE_FAILURE],
+        schema: Schemas.METADATA,
+        endpoint: '/metadata',
+        data: md
+      }
+    }).then((action) => {
+      // TODO - this isn't getting called
+      if (action.type == METADATA_SUCCESS) {
+        cancelMetadataEdit(metadata.keyId, metadata.subject)
+      }
+    })
+  }
+}
+
+export const METADATA_BY_KEY_REQUEST = 'METADATA_BY_KEY_REQUEST'
+export const METADATA_BY_KEY_SUCCESS = 'METADATA_BY_KEY_SUCCESS'
+export const METADATA_BY_KEY_FAILURE = 'METADATA_BY_KEY_FAILURE'
+
+export function fetchMetadataByKey (key, page = 1, pageSize = 25) {
+  return ({
+    [CALL_API]: {
+      types: [METADATA_BY_KEY_REQUEST, METADATA_BY_KEY_SUCCESS, METADATA_BY_KEY_FAILURE],
+      schema: Schemas.METADATA,
+      endpoint: `/metadata?key=${key}`,
+      data: { key, page, pageSize },
+      key,
+      page,
+      pageSize
+    }
+  })
+}
+
+export function loadMetadataByKey (key, page = 1, pageSize = 25) {
+  return (dispatch) => {
+    // TODO - add pagination & pagination check
+    return dispatch(fetchMetadataByKey(key, page, pageSize))
+  }
+}

--- a/src/js/components/DataTable.js
+++ b/src/js/components/DataTable.js
@@ -1,3 +1,5 @@
+// DEPRICATE - No longer works -> Data is now an array of objects not array of arrays
+
 import React, { PropTypes } from 'react'
 import Spinner from './Spinner'
 import { fieldsProps } from '../propTypes/datasetRefProps.js'
@@ -40,7 +42,7 @@ const DataTable = ({ data, fields, fetching, fetchedAll, error, onLoadMore }) =>
 }
 
 DataTable.propTypes = {
-  data: PropTypes.arrayOf(PropTypes.array),
+  data: PropTypes.arrayOf(PropTypes.object),
   fields: fieldsProps,
   fetching: PropTypes.bool,
   fetchedAll: PropTypes.bool,

--- a/src/js/components/DatasetHeader.js
+++ b/src/js/components/DatasetHeader.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react'
 
 import DatasetRefProps from '../propTypes/datasetRefProps.js'
 
-const DatasetHeader = ({ datasetRef, onDelete }) => {
+const DatasetHeader = ({ datasetRef, onDelete, onEditMetadata }) => {
   const { name, path, dataset } = datasetRef
 
   return (
@@ -11,7 +11,7 @@ const DatasetHeader = ({ datasetRef, onDelete }) => {
         <hr className='blue' />
         <a className='green right' href={`/downloads/package?path=${path}`}>| Download</a>
         { onDelete && <a className='red right' onClick={onDelete}>| Delete&nbsp;</a> }
-        <a className='green right'>Edit Metadata&nbsp;</a>
+        <a className='green right' onClick={onEditMetadata}>Edit Metadata&nbsp;</a>
         <h1 className='inline-block'>{ name }</h1>
         { dataset.title ? <h4 className='inline-block dt-string'>{ dataset.title }</h4> : undefined }
         <p className='path dt-string'>{ path }</p>
@@ -24,7 +24,8 @@ const DatasetHeader = ({ datasetRef, onDelete }) => {
 DatasetHeader.propTypes = {
   // dataset data model
   datasetRef: DatasetRefProps,
-  onDelete: PropTypes.func
+  onDelete: PropTypes.func,
+  onEditMetadata: PropTypes.func
 }
 
 DatasetHeader.defaultProps = {

--- a/src/js/components/DatasetHeader.js
+++ b/src/js/components/DatasetHeader.js
@@ -9,8 +9,9 @@ const DatasetHeader = ({ datasetRef, onDelete }) => {
     <div className='row'>
       <header className='blue page-header col-md-12'>
         <hr className='blue' />
-        <a className='green right' href={`/downloads/package?path=${path}`}>Download</a>
-        { onDelete && <a className='red right' onClick={onDelete}>Delete&nbsp;</a> }
+        <a className='green right' href={`/downloads/package?path=${path}`}>| Download</a>
+        { onDelete && <a className='red right' onClick={onDelete}>| Delete&nbsp;</a> }
+        <a className='green right'>Edit Metadata&nbsp;</a>
         <h1 className='inline-block'>{ name }</h1>
         { dataset.title ? <h4 className='inline-block dt-string'>{ dataset.title }</h4> : undefined }
         <p className='path dt-string'>{ path }</p>

--- a/src/js/components/FieldsList.js
+++ b/src/js/components/FieldsList.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
 import { fieldsProps } from '../propTypes/datasetRefProps.js'
 
 function descriptionTrigger (i, fn) {
@@ -7,26 +7,14 @@ function descriptionTrigger (i, fn) {
   }
 }
 
-function editTrigger (fn) {
-  return () => {
-    fn()
-  }
-}
-
 export default class FieldsList extends React.Component {
   constructor (props) {
     super(props)
-    this.state = {
-      descriptionIndex: -1,
-      editMetadata: false
-    };
+    this.state = {descriptionIndex: -1};
 
     [
       'onShowDescription',
-      'onHideDescription',
-      'onEditMetadata',
-      'onShowMetadata',
-      'renderFields'
+      'onHideDescription'
     ].forEach((m) => { this[m] = this[m].bind(this) })
   }
 
@@ -38,48 +26,24 @@ export default class FieldsList extends React.Component {
     this.setState({ descriptionIndex: -1 })
   }
 
-  onEditMetadata () {
-    this.setState({ editMetadata: true })
-  }
-
-  onShowMetadata () {
-    this.setState({ editMetadata: false })
-  }
-
-  renderFields (fields, descriptionIndex, editMetadata) {
-    if (editMetadata) {
-      return (
-        <p>TIME TO EDIT SOME METADATAAAA</p>
-      )
-    } else {
-      return (<p>Fields yay!</p>)
-      // fields.map((field, i) => {
-      //   return (
-      //     <div key={i} className='relative field col-md-4' onMouseEnter={descriptionTrigger(i, this.onShowDescription)} onMouseLeave={descriptionTrigger(i, this.onHideDescription)}>
-      //       <p className='purple field-title' >{field.title || field.name}<span className={`type dt-${field.type}`}><small>                                                                                  {field.type}</small></span>
-      //       </p>
-      //       { field.description && (i === descriptionIndex) && (field.description !== field.title) ? <div className='absolute description'><div className='description-tail' />{field.description}</div> : undefined }
-      //     </div>
-      //   )
-      // })
-    }
-  }
-
   render () {
     const { fields } = this.props
     const descriptionIndex = this.state.descriptionIndex
-    const editMetadata = this.state.editMetadata
+
     return (
-      <div className='wrapper'>
-        <div className='Row'>
-          <div className='col-md-12'>
-            { editMetadata ? <a className='right' onClick={editTrigger(this.onShowMetadata)}>Show Metadata</a> : <a className='right' onClick={editTrigger(this.onEditMetadata)}>Edit Metadata</a> }
-          </div>
-        </div>
-        <div className='Row'>
-          <div className='col-md-12'>
-            {this.renderFields(fields, descriptionIndex, editMetadata)}
-          </div>
+      <div className='Row'>
+        <div className='col-md-12'>
+          {
+            fields.map((field, i) => {
+              return (
+                <div key={i} className='relative field col-md-4' onMouseEnter={descriptionTrigger(i, this.onShowDescription)} onMouseLeave={descriptionTrigger(i, this.onHideDescription)}>
+                  <p className='purple field-title' >{field.title || field.name}<span className={`type dt-${field.type}`}><small>                                                                                                                                              {field.type}</small></span>
+                  </p>
+                  { field.description && (i === descriptionIndex) && (field.description !== field.title) ? <div className='absolute description'><div className='description-tail' />{field.description}</div> : undefined }
+                </div>
+              )
+            })
+          }
         </div>
       </div>
     )

--- a/src/js/components/FieldsList.js
+++ b/src/js/components/FieldsList.js
@@ -10,11 +10,16 @@ function descriptionTrigger (i, fn) {
 export default class FieldsList extends React.Component {
   constructor (props) {
     super(props)
-    this.state = {descriptionIndex: -1};
+    this.state = {
+      descriptionIndex: -1,
+      editMetadata: false
+    };
 
     [
       'onShowDescription',
-      'onHideDescription'
+      'onHideDescription',
+      'onEditMetadata',
+      'onShowMetadata'
     ].forEach((m) => { this[m] = this[m].bind(this) })
   }
 
@@ -26,21 +31,47 @@ export default class FieldsList extends React.Component {
     this.setState({ descriptionIndex: -1 })
   }
 
+  onEditMetadata () {
+    this.setState( editMetadata: true )
+  }
+
+  onShowMetadata () {
+    this.setState( editMetadata: false )
+  }
+
+  renderFields() {
+    if ( editMetadata ) {
+      return (
+        <p>TIME TO EDIT SOME METADATAAAA</p>
+        )
+    } else {
+      fields.map((field, i) => {
+        return (
+          <div key={i} className='relative field col-md-4' onMouseEnter={descriptionTrigger(i, this.onShowDescription)} onMouseLeave={descriptionTrigger(i, this.onHideDescription)}>
+            <p className='purple field-title' >{field.title || field.name}<span className={`type dt-${field.type}`}><small>  {field.type}</small></span>
+            </p>
+            { field.description && (i === descriptionIndex) && (field.description !== field.title) ? <div className='absolute description'><div className='description-tail' />{field.description}</div> : undefined }
+          </div>
+        )
+      })
+    }
+  }
+
   render () {
     const { fields } = this.props
     const descriptionIndex = this.state.descriptionIndex
+    const showEditMetadata = this.state.showEditMetadata
     return (
-      <div className='Row'>
-        <div className='col-md-12'>
-          {fields.map((field, i) => {
-            return (
-              <div key={i} className='relative field col-md-4' onMouseEnter={descriptionTrigger(i, this.onShowDescription)} onMouseLeave={descriptionTrigger(i, this.onHideDescription)}>
-                <p className='purple field-title' >{field.title || field.name}<span className={`type dt-${field.type}`}><small>                                                                                                                                                                                                                                                                                                                                                                          {field.type}</small></span>
-                </p>
-                { field.description && (i === descriptionIndex) && (field.description !== field.title) ? <div className='absolute description'><div className='description-tail' />{field.description}</div> : undefined }
-              </div>
-            )
-          })}
+      <div className='wrapper'>
+        <div className='Row'>
+          <div className='col-md-12'>
+            { editMetadata ? <a className='right' onClick({ () => this.onShowMetadata})>Show Metadata</a> : <a className='right' onClick={ () => this.onEditMetadata}>Edit Metadata</a> }
+          </div>
+        </div>
+        <div className='Row'>
+          <div className='col-md-12'>
+            
+          </div>
         </div>
       </div>
     )

--- a/src/js/components/FieldsList.js
+++ b/src/js/components/FieldsList.js
@@ -7,6 +7,12 @@ function descriptionTrigger (i, fn) {
   }
 }
 
+function editTrigger (fn) {
+  return () => {
+    fn()
+  }
+}
+
 export default class FieldsList extends React.Component {
   constructor (props) {
     super(props)
@@ -19,7 +25,8 @@ export default class FieldsList extends React.Component {
       'onShowDescription',
       'onHideDescription',
       'onEditMetadata',
-      'onShowMetadata'
+      'onShowMetadata',
+      'renderFields'
     ].forEach((m) => { this[m] = this[m].bind(this) })
   }
 
@@ -32,45 +39,46 @@ export default class FieldsList extends React.Component {
   }
 
   onEditMetadata () {
-    this.setState( editMetadata: true )
+    this.setState({ editMetadata: true })
   }
 
   onShowMetadata () {
-    this.setState( editMetadata: false )
+    this.setState({ editMetadata: false })
   }
 
-  renderFields() {
-    if ( editMetadata ) {
+  renderFields (fields, descriptionIndex, editMetadata) {
+    if (editMetadata) {
       return (
         <p>TIME TO EDIT SOME METADATAAAA</p>
-        )
+      )
     } else {
-      fields.map((field, i) => {
-        return (
-          <div key={i} className='relative field col-md-4' onMouseEnter={descriptionTrigger(i, this.onShowDescription)} onMouseLeave={descriptionTrigger(i, this.onHideDescription)}>
-            <p className='purple field-title' >{field.title || field.name}<span className={`type dt-${field.type}`}><small>  {field.type}</small></span>
-            </p>
-            { field.description && (i === descriptionIndex) && (field.description !== field.title) ? <div className='absolute description'><div className='description-tail' />{field.description}</div> : undefined }
-          </div>
-        )
-      })
+      return (<p>Fields yay!</p>)
+      // fields.map((field, i) => {
+      //   return (
+      //     <div key={i} className='relative field col-md-4' onMouseEnter={descriptionTrigger(i, this.onShowDescription)} onMouseLeave={descriptionTrigger(i, this.onHideDescription)}>
+      //       <p className='purple field-title' >{field.title || field.name}<span className={`type dt-${field.type}`}><small>                                                                                  {field.type}</small></span>
+      //       </p>
+      //       { field.description && (i === descriptionIndex) && (field.description !== field.title) ? <div className='absolute description'><div className='description-tail' />{field.description}</div> : undefined }
+      //     </div>
+      //   )
+      // })
     }
   }
 
   render () {
     const { fields } = this.props
     const descriptionIndex = this.state.descriptionIndex
-    const showEditMetadata = this.state.showEditMetadata
+    const editMetadata = this.state.editMetadata
     return (
       <div className='wrapper'>
         <div className='Row'>
           <div className='col-md-12'>
-            { editMetadata ? <a className='right' onClick({ () => this.onShowMetadata})>Show Metadata</a> : <a className='right' onClick={ () => this.onEditMetadata}>Edit Metadata</a> }
+            { editMetadata ? <a className='right' onClick={editTrigger(this.onShowMetadata)}>Show Metadata</a> : <a className='right' onClick={editTrigger(this.onEditMetadata)}>Edit Metadata</a> }
           </div>
         </div>
         <div className='Row'>
           <div className='col-md-12'>
-            
+            {this.renderFields(fields, descriptionIndex, editMetadata)}
           </div>
         </div>
       </div>

--- a/src/js/components/Metadata.js
+++ b/src/js/components/Metadata.js
@@ -1,0 +1,59 @@
+import React, { PropTypes } from 'react'
+
+// order of special keys. most important key is **LAST**
+const keys = ['title', 'description', 'theme', 'keyword']
+
+// sortPriorityKeys returns a function to be used with Array.prototype.sort()
+// it accepts an array of items to prioritize over natural order comparison.
+// aka: let's you pull stuff out of an alphabetical list to put at the top.
+function priorityCompare (list) {
+  list = list.reverse()
+  return (a, b) => {
+    const ai = list.findIndex((k) => k == a)
+    const bi = list.findIndex((k) => k == b)
+
+    // if neither is a priority string, regular comparison
+    if (ai == -1 && bi == -1) {
+      const nameA = a.toLowerCase() // ignore upper and lowercase
+      const nameB = b.toLowerCase() // ignore upper and lowercase
+      if (nameA < nameB) {
+        return -1
+      }
+      if (nameA > nameB) {
+        return 1
+      }
+    } else if (ai > bi) {
+      return -1
+    } else if (ai < bi) {
+      return 1
+    }
+
+    // equal
+    return 0
+  }
+}
+
+// Metadata is a static metadata viewer
+const Metadata = ({ metadata }) => {
+  return (
+    <div className='metadata'>
+      {Object.keys(metadata).sort(priorityCompare(keys)).map((key) => {
+        return (
+          <div key={key}>
+            <label className='yellow meta label'>{key}</label>
+            <p>{metadata[key]}</p>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+Metadata.propTypes = {
+  metadata: PropTypes.object
+}
+
+Metadata.defaultProps = {
+}
+
+export default Metadata

--- a/src/js/components/form/LanguageInput.js
+++ b/src/js/components/form/LanguageInput.js
@@ -33,7 +33,7 @@ LanguageInput.propTypes = {
   // required name for the field
   name: PropTypes.string.isRequired,
   // value to display in the field
-  value: PropTypes.string.isRequired,
+  value: PropTypes.string,
   // an error message to displacy
   error: PropTypes.string,
   // weather or not to actually display any passed-in errors

--- a/src/js/components/form/LanguageInput.js
+++ b/src/js/components/form/LanguageInput.js
@@ -4,7 +4,10 @@ const LanguageInput = ({ label, name, value, error, showError, helpText, showHel
   return (
     <div className={(error && showError) ? 'validFormField form-group has-error' : 'validFormField form-group'}>
       {label && <label className='control-label' htmlFor={name}>{label}</label>}
-      <select id={name} name={name} className='form-control' value={value} onChange={(e) => { onChange(name, e.target.value, e) }}>
+      <select id={name} name={name} className='form-control' value={value} multiple onChange={(e) => {
+        const languages = Array.from(e.target.options).filter(option => { return option.selected && option.value }).map(option => { return option.value })
+        onChange(name, languages, e)
+      }}>
         <option value=''>-unknown-</option>
         <option value='arabic'>arabic</option>
         <option value='bengali'>bengali</option>
@@ -33,7 +36,7 @@ LanguageInput.propTypes = {
   // required name for the field
   name: PropTypes.string.isRequired,
   // value to display in the field
-  value: PropTypes.string,
+  value: PropTypes.arrayOf(PropTypes.string),
   // an error message to displacy
   error: PropTypes.string,
   // weather or not to actually display any passed-in errors

--- a/src/js/components/form/LanguageInput.js
+++ b/src/js/components/form/LanguageInput.js
@@ -41,9 +41,9 @@ LanguageInput.propTypes = {
   // short message to help the user
   helpText: PropTypes.string,
   // weather to show help text or not
-  showHelpText: PropTypes.bool
+  showHelpText: PropTypes.bool,
   // change handler func. will be called with (name, value, event)
-  onChange: PropTypes.func.isRequired,
+  onChange: PropTypes.func.isRequired
 }
 
 LanguageInput.defaultProps = {

--- a/src/js/components/form/LanguageInput.js
+++ b/src/js/components/form/LanguageInput.js
@@ -1,33 +1,45 @@
 import React, { PropTypes } from 'react'
 
-const LanguageInput = ({ label, name, value, error, showError, helpText, showHelpText, onChange }) => {
-  return (
-    <div className={(error && showError) ? 'validFormField form-group has-error' : 'validFormField form-group'}>
-      {label && <label className='control-label' htmlFor={name}>{label}</label>}
-      <select id={name} name={name} className='form-control' value={value} multiple onChange={(e) => {
-        const languages = Array.from(e.target.options).filter(option => { return option.selected && option.value }).map(option => { return option.value })
-        onChange(name, languages, e)
-      }}>
-        <option value=''>-unknown-</option>
-        <option value='arabic'>arabic</option>
-        <option value='bengali'>bengali</option>
-        <option value='chinese'>chinese</option>
-        <option value='english'>english</option>
-        <option value='french'>french</option>
-        <option value='german'>german</option>
-        <option value='hindi'>hindi</option>
-        <option value='japanese'>japanese</option>
-        <option value='javanese'>javanese</option>
-        <option value='korean'>korean</option>
-        <option value='lahanda'>lahanda</option>
-        <option value='portuguese'>portuguese</option>
-        <option value='russian'>russian</option>
-        <option value='spanish'>spanish</option>
-      </select>
-      {(error !== '' && showError) ? <div className='control-label'>{error}</div> : undefined}
-      {(helpText && showHelpText) && <i className='help hint'>{helpText}</i>}
-    </div>
-  )
+class LanguageInput extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {};
+    [
+      'handleOnChange'
+    ].forEach((m) => { this[m] = this[m].bind(this) })
+  }
+
+  handleOnChange (e) {
+    const languages = Array.from(e.target.options).filter(option => { return option.selected && option.value }).map(option => { return option.value })
+    this.props.onChange(this.props.name, languages, e)
+  }
+
+  render () {
+    const { label, name, value, error, showError, helpText, showHelpText } = this.props
+    return (
+      <div className={(error && showError) ? 'validFormField form-group has-error' : 'validFormField form-group'}>
+        {label && <label className='control-label' htmlFor={name}>{label}</label>}
+        <select id={name} name={name} className='form-control' value={value} multiple onChange={(e) => this.handleOnChange(e)}>
+          <option value='arabic'>arabic</option>
+          <option value='bengali'>bengali</option>
+          <option value='chinese'>chinese</option>
+          <option value='english'>english</option>
+          <option value='french'>french</option>
+          <option value='german'>german</option>
+          <option value='hindi'>hindi</option>
+          <option value='japanese'>japanese</option>
+          <option value='javanese'>javanese</option>
+          <option value='korean'>korean</option>
+          <option value='lahanda'>lahanda</option>
+          <option value='portuguese'>portuguese</option>
+          <option value='russian'>russian</option>
+          <option value='spanish'>spanish</option>
+        </select>
+        {(error !== '' && showError) ? <div className='control-label'>{error}</div> : undefined}
+        {(helpText && showHelpText) && <i className='help hint'>{helpText}</i>}
+      </div>
+    )
+  }
 }
 
 LanguageInput.propTypes = {

--- a/src/js/components/form/MetadataForm.js
+++ b/src/js/components/form/MetadataForm.js
@@ -52,7 +52,7 @@ const MetadataForm = ({ data, validation, onChange, onCancel, onSubmit, showHelp
         error={validation.description}
         onChange={onChange}
       />
-      <ValidInput
+      <TagInput
         name='theme'
         label='Category'
         helpText='Main thematic category of the dataset'
@@ -144,13 +144,7 @@ MetadataForm.propTypes = {
   data: PropTypes.shape({
     title: PropTypes.string.isRequired,
     description: PropTypes.string,
-    // POD metadata says theme is an array of strings,
-    // however the ValidInput component, to which it gets passed
-    // requires a string, not array of strings
     theme: PropTypes.arrayOf(PropTypes.string),
-    // POD metadata says keyword is an array of strings,
-    // however the TagInput component, to which it gets passed
-    // requires a string, not array of strings
     keyword: PropTypes.arrayOf(PropTypes.string),
     modified: PropTypes.instanceOf(Date),
     issued: PropTypes.instanceOf(Date),
@@ -162,7 +156,8 @@ MetadataForm.propTypes = {
     // POD metadata says language is an array of strings,
     // however the UrlInput component, to which it gets passed
     // requires a string, not array of strings
-    language: PropTypes.arrayOf(PropTypes.string),
+    // language: PropTypes.arrayOf(PropTypes.string),
+    language: PropTypes.string,
     landingPage: PropTypes.string
 
   }).isRequired,

--- a/src/js/components/form/MetadataForm.js
+++ b/src/js/components/form/MetadataForm.js
@@ -34,7 +34,7 @@ const MetadataForm = ({ data, validation, onChange, onCancel, onSubmit, showHelp
 
   return (
     <div className='metadata form'>
-      { meta.title ? <ValidInput
+      <ValidInput
         name='title'
         label='Title'
         helpText='Human-readable name of the asset. Should be in plain English and include sufficient detail to facilitate search and discovery.'
@@ -42,7 +42,7 @@ const MetadataForm = ({ data, validation, onChange, onCancel, onSubmit, showHelp
         value={meta.title}
         error={validation.title}
         onChange={onChange}
-      /> : undefined }
+      />
       <ValidTextarea
         name='description'
         label='Description'
@@ -55,7 +55,7 @@ const MetadataForm = ({ data, validation, onChange, onCancel, onSubmit, showHelp
       <TagInput
         name='theme'
         label='Category'
-        helpText='Main thematic category of the dataset'
+        helpText='Main thematic categories of the dataset, use commas to seperate'
         showHelpText={showHelpText}
         value={meta.theme}
         onChange={onChange}
@@ -63,7 +63,7 @@ const MetadataForm = ({ data, validation, onChange, onCancel, onSubmit, showHelp
       <TagInput
         name='keyword'
         label='Tags'
-        helpText='Tags (or keywords) help users discover this dataset; please include terms that would be used by technical and non-technical users'
+        helpText='Tags (or keywords) help users discover this dataset; please include terms that would be used by technical and non-technical users. Please use commas to seperate'
         showHelpText={showHelpText}
         value={meta.keyword}
         onChange={onChange}

--- a/src/js/components/form/MetadataForm.js
+++ b/src/js/components/form/MetadataForm.js
@@ -24,6 +24,7 @@ import ValidDateTimeInput from './ValidDateTimeInput'
 // programCode
 // √ license
 
+// const MetadataForm = ({ data, validation, onChange, onCancel, onSubmit, showHelpText }) => {
 const MetadataForm = ({ data, validation, onChange, onCancel, onSubmit, showHelpText }) => {
   const meta = data
   const handleSubmit = (e) => {
@@ -33,7 +34,7 @@ const MetadataForm = ({ data, validation, onChange, onCancel, onSubmit, showHelp
 
   return (
     <div className='metadata form'>
-      <ValidInput
+      { meta.title ? <ValidInput
         name='title'
         label='Title'
         helpText='Human-readable name of the asset. Should be in plain English and include sufficient detail to facilitate search and discovery.'
@@ -41,7 +42,7 @@ const MetadataForm = ({ data, validation, onChange, onCancel, onSubmit, showHelp
         value={meta.title}
         error={validation.title}
         onChange={onChange}
-      />
+      /> : undefined }
       <ValidTextarea
         name='description'
         label='Description'
@@ -142,27 +143,27 @@ const MetadataForm = ({ data, validation, onChange, onCancel, onSubmit, showHelp
 MetadataForm.propTypes = {
   data: PropTypes.shape({
     title: PropTypes.string.isRequired,
-    description: PropTypes.string.isRequired,
+    description: PropTypes.string,
     // POD metadata says theme is an array of strings,
     // however the ValidInput component, to which it gets passed
     // requires a string, not array of strings
-    theme: PropTypes.arrayOf(PropTypes.string).isRequired,
+    theme: PropTypes.arrayOf(PropTypes.string),
     // POD metadata says keyword is an array of strings,
     // however the TagInput component, to which it gets passed
     // requires a string, not array of strings
-    keyword: PropTypes.arrayOf(PropTypes.string).isRequired,
-    modified: PropTypes.instanceOf(Date).isRequired,
-    issued: PropTypes.instanceOf(Date).isRequired,
-    identifier: PropTypes.string.isRequired,
+    keyword: PropTypes.arrayOf(PropTypes.string),
+    modified: PropTypes.instanceOf(Date),
+    issued: PropTypes.instanceOf(Date),
+    identifier: PropTypes.string,
     // may be too strict:
     // accessLevel: PropTypes.oneOf(['public', 'restricted public', 'non-public']),isRequired,
-    accessLevel: PropTypes.string.isRequired,
-    license: PropTypes.string.isRequired,
+    accessLevel: PropTypes.string,
+    license: PropTypes.string,
     // POD metadata says language is an array of strings,
     // however the UrlInput component, to which it gets passed
     // requires a string, not array of strings
     language: PropTypes.arrayOf(PropTypes.string),
-    landingPage: PropTypes.string.isRequired
+    landingPage: PropTypes.string
 
   }).isRequired,
   validation: PropTypes.shape({
@@ -177,7 +178,10 @@ MetadataForm.propTypes = {
 }
 
 MetadataForm.defaultProps = {
-  validation: {},
+  validation: {
+    title: '',
+    description: ''
+  },
   showHelpText: false
 }
 

--- a/src/js/components/form/MetadataForm.js
+++ b/src/js/components/form/MetadataForm.js
@@ -156,8 +156,8 @@ MetadataForm.propTypes = {
     // POD metadata says language is an array of strings,
     // however the UrlInput component, to which it gets passed
     // requires a string, not array of strings
-    // language: PropTypes.arrayOf(PropTypes.string),
-    language: PropTypes.string,
+    language: PropTypes.arrayOf(PropTypes.string),
+    // language: PropTypes.string,
     landingPage: PropTypes.string
 
   }).isRequired,

--- a/src/js/components/form/MetadataForm.js
+++ b/src/js/components/form/MetadataForm.js
@@ -11,6 +11,8 @@ import ValidSelect from './ValidSelect'
 import ValidLicenseInput from './ValidLicenseInput'
 import ValidDateTimeInput from './ValidDateTimeInput'
 
+import DatasetRefProps from '../../propTypes/datasetRefProps.js'
+
 // Required fields to pass POD spec:
 // √ title
 // √ description
@@ -25,11 +27,15 @@ import ValidDateTimeInput from './ValidDateTimeInput'
 // √ license
 
 // const MetadataForm = ({ data, validation, onChange, onCancel, onSubmit, showHelpText }) => {
-const MetadataForm = ({ data, validation, onChange, onCancel, onSubmit, showHelpText }) => {
-  const meta = data
+const MetadataForm = ({ datasetRef, validation, onChange, onCancel, onSubmit, showHelpText }) => {
+  const meta = datasetRef.dataset
   const handleSubmit = (e) => {
     e.preventDefault()
-    onSubmit(data, e)
+    onSubmit(datasetRef, e)
+  }
+  const handleCancel = (e) => {
+    e.preventDefault()
+    onCancel(datasetRef.props, e)
   }
 
   return (
@@ -134,37 +140,14 @@ const MetadataForm = ({ data, validation, onChange, onCancel, onSubmit, showHelp
         onChange={onChange}
       />
       <br />
-      <button className='btn' onClick={onCancel}>Cancel</button>
+      <button className='btn' onClick={handleCancel}>Cancel</button>
       <input className='btn btn-primary' type='submit' value='Save' onClick={handleSubmit} />
     </div>
   )
 }
 
 MetadataForm.propTypes = {
-  data: PropTypes.shape({
-    title: PropTypes.string.isRequired,
-    description: PropTypes.string,
-    theme: PropTypes.arrayOf(PropTypes.string),
-    keyword: PropTypes.arrayOf(PropTypes.string),
-    modified: PropTypes.instanceOf(Date),
-    issued: PropTypes.instanceOf(Date),
-    identifier: PropTypes.string,
-    // may be too strict:
-    // accessLevel: PropTypes.oneOf(['public', 'restricted public', 'non-public']),isRequired,
-    accessLevel: PropTypes.string,
-    license: PropTypes.string,
-    // POD metadata says language is an array of strings,
-    // however the UrlInput component, to which it gets passed
-    // requires a string, not array of strings
-    language: PropTypes.arrayOf(PropTypes.string),
-    // language: PropTypes.string,
-    landingPage: PropTypes.string
-
-  }).isRequired,
-  validation: PropTypes.shape({
-    title: PropTypes.string,
-    description: PropTypes.string
-  }),
+  datasetRef: DatasetRefProps,
   showHelpText: PropTypes.bool,
 
   onChange: PropTypes.func.isRequired,

--- a/src/js/components/form/MonthCalendar.js
+++ b/src/js/components/form/MonthCalendar.js
@@ -81,7 +81,7 @@ class MonthCalendar extends React.Component {
   render () {
     // const { value } = this.props;
     const { displayMonth } = this.state
-    const { onMouseDown, onTouchEnd } = props
+    const { onMouseDown, onTouchEnd } = this.props
 
     let startDay = displayMonth.toString().split(' ')[0].toLowerCase()
     let offset = days[startDay]

--- a/src/js/components/form/TagInput.js
+++ b/src/js/components/form/TagInput.js
@@ -6,7 +6,7 @@ class TagInput extends React.Component {
     super(props)
     this.state = { tagString: '' };
     [
-      'setTagString'
+      'handleOnChange'
     ].forEach((m) => { this[m] = this[m].bind(this) })
   }
 
@@ -14,8 +14,11 @@ class TagInput extends React.Component {
     this.setState({ tagString: this.props.value.join(', ')})
   }
 
-  setTagString (tagString) {
-    this.setState({ tagString: tagString })
+  handleOnChange (e) {
+    this.setState({ tagString: e.target.value })
+    let tags = e.target.value.trim().split(',').map(i => { return i.trim() }).filter(i => i)
+    console.log(tags)
+    this.props.onChange(this.props.name, tags, e)
   }
 
   render () {
@@ -30,13 +33,7 @@ class TagInput extends React.Component {
           className='form-control'
           value={this.state.tagString}
           placeholder={placeholder}
-          onChange={(e) => {
-            this.setTagString(e.target.value)
-            let tags = e.target.value.trim().split(', ').map(i => { return i.trim() }).filter(i => i)
-            console.log(tags)
-            onChange(name, tags, e)
-          }
-          }
+          onChange={(e) => this.handleOnChange(e)}
         />
         {(error !== '' && showError) ? <div className='control-label'>{error}</div> : undefined}
         {(helpText && showHelpText) && <i className='help hint'>{helpText}</i>}

--- a/src/js/components/form/TagInput.js
+++ b/src/js/components/form/TagInput.js
@@ -30,7 +30,7 @@ TagInput.propTypes = {
   // an error message to displacy
   error: PropTypes.string,
   // value to display in the field
-  value: PropTypes.string.isRequired,
+  value: PropTypes.string,
   // placeholder text for an empty field. default: ""
   placeholder: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   // change handler func. will be called with (name, value, event)

--- a/src/js/components/form/TagInput.js
+++ b/src/js/components/form/TagInput.js
@@ -32,7 +32,7 @@ TagInput.propTypes = {
   // value to display in the field
   value: PropTypes.string.isRequired,
   // placeholder text for an empty field. default: ""
-  placeholder: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  placeholder: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   // change handler func. will be called with (name, value, event)
   onChange: PropTypes.func.isRequired,
   // short message to help the user

--- a/src/js/components/form/TagInput.js
+++ b/src/js/components/form/TagInput.js
@@ -10,9 +10,18 @@ const TagInput = ({ label, name, showError, error, value, placeholder, onChange,
         name={name}
         type='text'
         className='form-control'
-        value={value}
+        value={value.join(', ')}
         placeholder={placeholder}
-        onChange={(e) => { onChange(name, e.target.value, e) }}
+        onChange={(e) => {
+          let tags = e.target.value.split(', ').map((val, i, array) => {
+            return array.length === 1 || i + 1 === array.length ? val : val.trim()
+          })
+          if (tags.length === 1 && tags[0].trim() == '') {
+            tags = []
+          }
+          onChange(name, tags, e)
+        }
+        }
       />
       {(error !== '' && showError) ? <div className='control-label'>{error}</div> : undefined}
       {(helpText && showHelpText) && <i className='help hint'>{helpText}</i>}

--- a/src/js/components/form/TagInput.js
+++ b/src/js/components/form/TagInput.js
@@ -1,32 +1,48 @@
 import React, { PropTypes } from 'react'
 
 // TODO - work in progress
-const TagInput = ({ label, name, showError, error, value, placeholder, onChange, helpText, showHelpText }) => {
-  return (
-    <div className={(error && showError) ? 'validFormField form-group has-error' : 'validFormField form-group'}>
-      {label ? <label className='control-label' htmlFor={name}>{label}</label> : undefined }
-      <input
-        id={name}
-        name={name}
-        type='text'
-        className='form-control'
-        value={value.join(', ')}
-        placeholder={placeholder}
-        onChange={(e) => {
-          let tags = e.target.value.split(', ').map((val, i, array) => {
-            return array.length === 1 || i + 1 === array.length ? val : val.trim()
-          })
-          if (tags.length === 1 && tags[0].trim() == '') {
-            tags = []
+class TagInput extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = { tagString: '' };
+    [
+      'setTagString'
+    ].forEach((m) => { this[m] = this[m].bind(this) })
+  }
+
+  componentWillMount () {
+    this.setState({ tagString: this.props.value.join(', ')})
+  }
+
+  setTagString (tagString) {
+    this.setState({ tagString: tagString })
+  }
+
+  render () {
+    const { label, name, showError, error, value, placeholder, onChange, helpText, showHelpText } = this.props
+    return (
+      <div className={(error && showError) ? 'validFormField form-group has-error' : 'validFormField form-group'}>
+        {label ? <label className='control-label' htmlFor={name}>{label}</label> : undefined }
+        <input
+          id={name}
+          name={name}
+          type='text'
+          className='form-control'
+          value={this.state.tagString}
+          placeholder={placeholder}
+          onChange={(e) => {
+            this.setTagString(e.target.value)
+            let tags = e.target.value.trim().split(', ').map(i => { return i.trim() }).filter(i => i)
+            console.log(tags)
+            onChange(name, tags, e)
           }
-          onChange(name, tags, e)
-        }
-        }
-      />
-      {(error !== '' && showError) ? <div className='control-label'>{error}</div> : undefined}
-      {(helpText && showHelpText) && <i className='help hint'>{helpText}</i>}
-    </div>
-  )
+          }
+        />
+        {(error !== '' && showError) ? <div className='control-label'>{error}</div> : undefined}
+        {(helpText && showHelpText) && <i className='help hint'>{helpText}</i>}
+      </div>
+    )
+  }
 }
 
 TagInput.propTypes = {

--- a/src/js/components/form/TagInput.js
+++ b/src/js/components/form/TagInput.js
@@ -30,7 +30,7 @@ TagInput.propTypes = {
   // an error message to displacy
   error: PropTypes.string,
   // value to display in the field
-  value: PropTypes.string,
+  value: PropTypes.arrayOf(PropTypes.string),
   // placeholder text for an empty field. default: ""
   placeholder: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   // change handler func. will be called with (name, value, event)

--- a/src/js/components/form/UrlInput.js
+++ b/src/js/components/form/UrlInput.js
@@ -33,13 +33,13 @@ UrlInput.propTypes = {
   // value to display in the field
   value: PropTypes.string.isRequired,
   // placeholder text for an empty field. default: ""
-  placeholder: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  placeholder: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   // short message to help the user
   helpText: PropTypes.string,
   // weather to show help text or not
-  showHelpText: PropTypes.bool
+  showHelpText: PropTypes.bool,
   // change handler func. will be called with (name, value, event)
-  onChange: PropTypes.func.isRequired,
+  onChange: PropTypes.func.isRequired
 }
 
 UrlInput.defaultProps = {

--- a/src/js/components/form/UrlInput.js
+++ b/src/js/components/form/UrlInput.js
@@ -31,7 +31,7 @@ UrlInput.propTypes = {
   // an error message to displacy
   error: PropTypes.string,
   // value to display in the field
-  value: PropTypes.string.isRequired,
+  value: PropTypes.string,
   // placeholder text for an empty field. default: ""
   placeholder: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   // short message to help the user

--- a/src/js/components/form/ValidDateInput.js
+++ b/src/js/components/form/ValidDateInput.js
@@ -36,7 +36,7 @@ ValidDateInput.propTypes = {
   // short message to help the user
   helpText: PropTypes.string,
   // weather to show help text or not
-  showHelpText: PropTypes.bool
+  showHelpText: PropTypes.bool,
   // className will set on the containing div
   className: PropTypes.string,
   // explicit control over weather or not to display validation

--- a/src/js/components/form/ValidDateTimeInput.js
+++ b/src/js/components/form/ValidDateTimeInput.js
@@ -32,11 +32,11 @@ ValidDateTimeInput.propTypes = {
   // error text, if any
   error: PropTypes.string,
   // explicit control over weather or not to display validation
-  showError: PropTypes.bool
+  showError: PropTypes.bool,
   // short message to help the user
   helpText: PropTypes.string,
   // weather to show help text or not
-  showHelpText: PropTypes.bool
+  showHelpText: PropTypes.bool,
   // className will set on the containing div
   className: PropTypes.string,
   // onChange in the form (value, name)

--- a/src/js/components/form/ValidInput.js
+++ b/src/js/components/form/ValidInput.js
@@ -27,7 +27,7 @@ ValidInput.propTypes = {
   // the type of input, default "text"
   type: PropTypes.string.isRequired,
   // value to display in the field
-  value: PropTypes.string.isRequired,
+  value: PropTypes.string,
   // placeholder text for an empty field. default: ""
   placeholder: PropTypes.string,
   // weather or not to actually display any passed-in errors

--- a/src/js/components/form/ValidLicenseInput.js
+++ b/src/js/components/form/ValidLicenseInput.js
@@ -6,7 +6,7 @@ const ValidLicenseInput = ({ label, name, className, value, showError, error, he
     <div className={`validFormField ${errorClass} ${className}`}>
       {label && <label className='control-label' htmlFor={name}>{label}</label>}
       <select id={name} name={name} className='form-control' value={value} onChange={(e) => { onChange(name, e.target.value, e) }}>
-        <option value='http://www.usa.gov/publicdomain/label/1.0/'>US Public Domain</option>
+        <option value='http://www.usa.gov/publicdomain/label/1.0/'>Public Domain</option>
         <option value='https://creativecommons.org/publicdomain/zero/1.0/'>CC0 - Creative Commons Zero Public Domain Dedication</option>
         <option value='http://opendatacommons.org/licenses/pddl/1.0/'>PDDL - Open Data Commons Public Domain Dedication and Licence</option>
         <option value='http://opendatacommons.org/licenses/by/1.0/'>ODC-By - Open Data Commons Attribution License</option>
@@ -29,7 +29,7 @@ ValidLicenseInput.propTypes = {
   // className will set on the containing div
   className: PropTypes.string,
   // value to display in the field
-  value: PropTypes.string.isRequired,
+  value: PropTypes.string,
   // weather or not to actually display any passed-in errors
   showError: PropTypes.bool,
   // an error message to display

--- a/src/js/components/form/ValidLicenseInput.js
+++ b/src/js/components/form/ValidLicenseInput.js
@@ -47,7 +47,7 @@ ValidLicenseInput.defaultProps = {
   error: undefined,
   showError: true,
   // https://project-open-data.cio.gov/open-licenses/
-  value: 'http://www.usa.gov/publicdomain/label/1.0/',
+  // value: 'http://www.usa.gov/publicdomain/label/1.0/',
   helpText: '',
   showHelpText: false
 }

--- a/src/js/components/form/ValidSelect.js
+++ b/src/js/components/form/ValidSelect.js
@@ -27,7 +27,7 @@ ValidSelect.propTypes = {
   // weather or not to actually display any passed-in errors
   showError: PropTypes.bool,
   // value to display in the field
-  value: PropTypes.string.isRequired,
+  value: PropTypes.string,
   // short message to help the user
   helpText: PropTypes.string,
   // weather to show help text or not

--- a/src/js/components/form/ValidTextarea.js
+++ b/src/js/components/form/ValidTextarea.js
@@ -27,7 +27,7 @@ ValidTextarea.propTypes = {
   // the type of input, default "text"
   type: PropTypes.string.isRequired,
   // value to display in the field
-  value: PropTypes.string.isRequired,
+  value: PropTypes.string,
   // placeholder text for an empty field. default: ""
   placeholder: PropTypes.string,
   // weather or not to actually display any passed-in errors

--- a/src/js/containers/Dataset.js
+++ b/src/js/containers/Dataset.js
@@ -11,6 +11,7 @@ import { selectDataset, selectDatasetData } from '../selectors/dataset'
 import { selectSessionUser } from '../selectors/session'
 // import { selectQueryById } from '../selectors/query';
 
+import DatasetDataGrid from '../components/DatasetDataGrid'
 import TabPanel from '../components/TabPanel'
 import List from '../components/List'
 import DatasetItem from '../components/item/DatasetItem'
@@ -163,7 +164,12 @@ class Dataset extends React.Component {
       <div className='col-md-12'>
         <hr className='green' />
         <h4 className='green'>Results</h4>
-        <DataTable results={results} onLoadMore={this.handleLoadMoreResults} />
+        <DatasetDataGrid
+          dataset={datasetRef && datasetRef.dataset}
+          data={data}
+          onLoadMore={this.handleLoadMoreResults}
+          bounds={bottomBox}
+              />
       </div>
     )
   }
@@ -201,7 +207,12 @@ class Dataset extends React.Component {
         <div className='col-md-12'>
           <hr className='green' />
           <h4 className='green'>Data</h4>
-          <DataTable fields={structure.schema.fields} data={data} fetching={false} fetchedAll onLoadMore={this.handleLoadMoreResults} />
+          <DatasetDataGrid
+            dataset={datasetRef && datasetRef.dataset}
+            data={data}
+            onLoadMore={this.handleLoadMoreResults}
+                // bounds={bottomBox}
+              />
         </div>
       </div>
     )
@@ -278,7 +289,6 @@ class Dataset extends React.Component {
 
     const { dataset, path } = datasetRef
     const { tabIndex, editMetadata } = this.state
-
     return (
       <div id='wrapper'>
         {
@@ -314,6 +324,7 @@ Dataset.propTypes = {
   query: PropTypes.object.isRequired,
   // results (if any)
   results: React.PropTypes.object,
+  path: PropTypes.string,
 
   // permissions stuff, will show things based on capabilities
   // permissions: PropTypes.object.isRequired,

--- a/src/js/containers/Dataset.js
+++ b/src/js/containers/Dataset.js
@@ -276,13 +276,13 @@ class Dataset extends React.Component {
       )
     }
 
-    const { dataset } = datasetRef
+    const { dataset, path } = datasetRef
     const { tabIndex, editMetadata } = this.state
 
     return (
       <div id='wrapper'>
         {
-          editMetadata ? <div className='container'><MetadataEditor datasetRef={datasetRef} /></div> : <div className='container'>
+          editMetadata ? <div className='container'><MetadataEditor path={path} /></div> : <div className='container'>
             <DatasetHeader datasetRef={datasetRef} onDelete={this.handleDeleteDataset} onDownload={this.handleDownloadDataset} onEditMetadata={this.changeEditMetadata} />
             <hr className='blue' />
             {this.renderTabPanel(readme, dataset, tabIndex)}

--- a/src/js/containers/Dataset.js
+++ b/src/js/containers/Dataset.js
@@ -19,12 +19,17 @@ import FieldsList from '../components/FieldsList'
 import QueryEditor from '../components/QueryEditor'
 import DataTable from '../components/DataTable'
 
+import MetadataEditor from '../containers/MetadataEditor.js'
+
 import DatasetRefProps from '../propTypes/datasetRefProps.js'
 
 class Dataset extends React.Component {
   constructor (props) {
     super(props)
-    this.state = {tabIndex: 0};
+    this.state = {
+      tabIndex: 0,
+      editMetadata: false
+    };
 
     [
       'handleRunQuery',
@@ -35,6 +40,7 @@ class Dataset extends React.Component {
       'handleDownloadDataset',
       'handleDeleteDataset',
       'changeTabIndex',
+      'changeEditMetadata',
       'renderFieldsList',
       'renderEditButtons',
       'renderResults',
@@ -123,6 +129,9 @@ class Dataset extends React.Component {
     this.setState({tabIndex: index})
   }
 
+  changeEditMetadata () {
+    this.state.editMetadata ? this.setState({editMetadata: false}) : this.setState({editMetadata: true})
+  }
   renderFieldsList (dataset) {
     if (dataset.structure && dataset.structure.schema) {
       return (<FieldsList fields={dataset.structure.schema.fields} />)
@@ -268,20 +277,22 @@ class Dataset extends React.Component {
     }
 
     const { dataset } = datasetRef
-    const tabIndex = this.state.tabIndex
+    const { tabIndex, editMetadata } = this.state
 
     return (
       <div id='wrapper'>
-        <div className='container'>
-          <DatasetHeader datasetRef={datasetRef} onDelete={this.handleDeleteDataset} onDownload={this.handleDownloadDataset} />
-          <hr className='blue' />
-          {this.renderTabPanel(readme, dataset, tabIndex)}
-          <div className='row'>
-            <div className='col-md-12'>
-              { this.renderEditButtons(this.props) }
+        {
+          editMetadata ? <div className='container'><MetadataEditor datasetRef={datasetRef} /></div> : <div className='container'>
+            <DatasetHeader datasetRef={datasetRef} onDelete={this.handleDeleteDataset} onDownload={this.handleDownloadDataset} onEditMetadata={this.changeEditMetadata} />
+            <hr className='blue' />
+            {this.renderTabPanel(readme, dataset, tabIndex)}
+            <div className='row'>
+              <div className='col-md-12'>
+                { this.renderEditButtons(this.props) }
+              </div>
             </div>
           </div>
-        </div>
+        }
       </div>
     )
   }

--- a/src/js/containers/Dataset.js
+++ b/src/js/containers/Dataset.js
@@ -226,11 +226,12 @@ class Dataset extends React.Component {
       return (
         <TabPanel
           index={tabIndex}
-          labels={['Description', 'Metadata', 'Data']}
+          labels={['Description', 'Fields', 'Data']}
           onSelectPanel={this.changeTabIndex}
           components={[
             this.renderReadme(readme, dataset),
             this.renderFieldsList(dataset),
+            // this.renderMetadata(dataset),
             this.renderData()
           ]}
         />
@@ -243,6 +244,7 @@ class Dataset extends React.Component {
           onSelectPanel={this.changeTabIndex}
           components={[
             this.renderFieldsList(dataset),
+            // this.renderMetadata(dataset),
             this.renderData()
           ]}
         />
@@ -265,7 +267,7 @@ class Dataset extends React.Component {
       )
     }
 
-    const { name, dataset } = datasetRef
+    const { dataset } = datasetRef
     const tabIndex = this.state.tabIndex
 
     return (

--- a/src/js/containers/Dataset.js
+++ b/src/js/containers/Dataset.js
@@ -282,7 +282,7 @@ class Dataset extends React.Component {
     return (
       <div id='wrapper'>
         {
-          editMetadata ? <div className='container'><MetadataEditor datasetRef={datasetRef} /></div> : <div className='container'>
+          editMetadata ? <div className='container'><MetadataEditor metadata={dataset} path={datasetRef.path} /></div> : <div className='container'>
             <DatasetHeader datasetRef={datasetRef} onDelete={this.handleDeleteDataset} onDownload={this.handleDownloadDataset} onEditMetadata={this.changeEditMetadata} />
             <hr className='blue' />
             {this.renderTabPanel(readme, dataset, tabIndex)}

--- a/src/js/containers/Dataset.js
+++ b/src/js/containers/Dataset.js
@@ -282,7 +282,7 @@ class Dataset extends React.Component {
     return (
       <div id='wrapper'>
         {
-          editMetadata ? <div className='container'><MetadataEditor metadata={dataset} path={datasetRef.path} /></div> : <div className='container'>
+          editMetadata ? <div className='container'><MetadataEditor datasetRef={datasetRef} /></div> : <div className='container'>
             <DatasetHeader datasetRef={datasetRef} onDelete={this.handleDeleteDataset} onDownload={this.handleDownloadDataset} onEditMetadata={this.changeEditMetadata} />
             <hr className='blue' />
             {this.renderTabPanel(readme, dataset, tabIndex)}

--- a/src/js/containers/MetadataEditor.js
+++ b/src/js/containers/MetadataEditor.js
@@ -7,9 +7,10 @@ import MetadataForm from '../components/form/MetadataForm'
 
 import { newMetadata, editMetadata, updateMetadata, cancelMetadataEdit, saveMetadata, loadMetadata } from '../actions/metadata'
 import { selectLocalMetadata, selectMetadata } from '../selectors/metadata'
+import { newDataset } from '../actions/dataset'
 import { selectDefaultKeyId } from '../selectors/keys'
 
-import { datasetProps } from '../propTypes/datasetRefProps'
+import DatasetRefProps from '../propTypes/datasetRefProps'
 
 class MetadataEditor extends React.Component {
   constructor (props) {
@@ -30,7 +31,8 @@ class MetadataEditor extends React.Component {
   }
 
   componentWillMount () {
-    this.props.newMetadata(this.props.metadata, this.props.path)
+    const { name, path, dataset } = this.props.datasetRef
+    this.props.newDataset({name: name, path: path}, dataset)
   }
 
   // componentWillReceiveProps (nextProps) {
@@ -67,7 +69,7 @@ class MetadataEditor extends React.Component {
   }
 
   render () {
-    const { metadata } = this.props
+    const { dataset } = this.props.datasetRef
     // const { savedMetadata, metadata, sessionKeyId } = this.props
     const { showHelp } = this.state
 
@@ -91,7 +93,7 @@ class MetadataEditor extends React.Component {
       <div className='metadata editor col-md-12'>
         <a className='helpToggle right' onClick={this.handleToggleHelp}>{showHelp ? 'hide help' : 'show help' }</a>
         <MetadataForm
-          data={metadata}
+          data={dataset}
           onChange={this.handleChange}
           onCancel={this.handleCancel}
           onSubmit={this.handleSave}
@@ -107,9 +109,9 @@ MetadataEditor.propTypes = {
   // sessionKeyId: PropTypes.string,
   // subjectHash: PropTypes.string.isRequired,
 
-  metadata: datasetProps,
+  datasetRef: DatasetRefProps,
   // savedMetadata: PropTypes.object,
-  path: PropTypes.string,
+  newDataset: PropTypes.func.isRequired,
   newMetadata: PropTypes.func.isRequired,
   editMetadata: PropTypes.func.isRequired,
   updateMetadata: PropTypes.func.isRequired,
@@ -133,6 +135,7 @@ function mapStateToProps (state, ownProps) {
 }
 
 export default connect(mapStateToProps, {
+  newDataset,
   newMetadata,
   editMetadata,
   updateMetadata,

--- a/src/js/containers/MetadataEditor.js
+++ b/src/js/containers/MetadataEditor.js
@@ -1,0 +1,140 @@
+import React, { PropTypes } from 'react'
+import { connect } from 'react-redux'
+import { Link } from 'react-router'
+
+import Metadata from '../components/Metadata'
+import MetadataForm from '../components/form/MetadataForm'
+
+import { newMetadata, editMetadata, updateMetadata, cancelMetadataEdit, saveMetadata, loadMetadata } from '../actions/metadata'
+import { selectLocalMetadata, selectMetadata } from '../selectors/metadata'
+import { selectDefaultKeyId } from '../selectors/keys'
+
+class MetadataEditor extends React.Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      showHelp: true
+    };
+
+    [
+      'handleNew',
+      'handleEdit',
+      'handleChange',
+      'handleCancel',
+      'handleSave',
+      'handleToggleHelp'
+    ].forEach((m) => { this[m] = this[m].bind(this) })
+  }
+
+  componentWillMount () {
+    if (this.props.sessionKeyId) {
+      this.props.loadMetadata(this.props.sessionKeyId, this.props.subjectHash)
+    }
+  }
+
+  componentWillReceiveProps (nextProps) {
+    if (nextProps.sessionKeyId != this.props.sessionKeyId) {
+      nextProps.loadMetadata(nextProps.sessionKeyId, this.props.subjectHash)
+    }
+  }
+
+  handleNew () {
+    this.props.newMetadata(this.props.sessionKeyId, this.props.subjectHash)
+  }
+
+  handleEdit () {
+    this.props.editMetadata(this.props.savedMetadata)
+  }
+
+  handleChange (name, value) {
+    const change = { meta: Object.assign({}, this.props.metadata.meta, { [name]: value }) }
+    this.props.updateMetadata(Object.assign({}, this.props.metadata, change))
+  }
+
+  handleCancel () {
+    this.props.cancelMetadataEdit(this.props.metadata)
+  }
+
+  handleSave (meta) {
+    this.props.saveMetadata({ keyId: this.props.sessionKeyId, subject: this.props.subjectHash, meta })
+    // TODO - this should be in a "then" clause on saveMetadata
+    this.props.cancelMetadataEdit(this.props.metadata)
+  }
+
+  handleToggleHelp () {
+    this.setState({ showHelp: !this.state.showHelp })
+  }
+
+  render () {
+    const { savedMetadata, metadata, sessionKeyId } = this.props
+    const { showHelp } = this.state
+
+    if (savedMetadata && !metadata) {
+      return (
+        <div className='metadata editor col-md-12'>
+          <Metadata metadata={savedMetadata.meta} />
+          {sessionKeyId ? <button className='btn btn-primary' onClick={this.handleEdit}>Edit</button> : <p><Link to='/signup'>Signup</Link> to edit metadata.</p>}
+        </div>
+      )
+    } else if (!metadata) {
+      return (
+        <div className='metadata editor col-md-12'>
+          {sessionKeyId ? <button className='btn btn-primary' onClick={this.handleNew}>Add Metadata</button> : <p><Link to='/signup'>Signup</Link> to add metadata.</p>}
+        </div>
+      )
+    }
+
+    return (
+      <div className='metadata editor col-md-12'>
+        <a className='helpToggle right' onClick={this.handleToggleHelp}>{showHelp ? 'hide help' : 'show help' }</a>
+        <MetadataForm
+          data={metadata.meta}
+          onChange={this.handleChange}
+          onCancel={this.handleCancel}
+          onSubmit={this.handleSave}
+          showHelpText={showHelp}
+        />
+        <br />
+      </div>
+    )
+  }
+}
+
+MetadataEditor.propTypes = {
+  sessionKeyId: PropTypes.string,
+  subjectHash: PropTypes.string.isRequired,
+
+  metadata: PropTypes.object,
+  savedMetadata: PropTypes.object,
+
+  newMetadata: PropTypes.func.isRequired,
+  editMetadata: PropTypes.func.isRequired,
+  updateMetadata: PropTypes.func.isRequired,
+  cancelMetadataEdit: PropTypes.func.isRequired,
+  loadMetadata: PropTypes.func.isRequired,
+  saveMetadata: PropTypes.func.isRequired
+}
+
+MetadataEditor.defaultProps = {
+}
+
+function mapStateToProps (state, ownProps) {
+  const subjectHash = ownProps.subjectHash
+  const sessionKeyId = selectDefaultKeyId(state)
+
+  return Object.assign({
+    sessionKeyId,
+    savedMetadata: selectMetadata(state, sessionKeyId, subjectHash),
+    metadata: selectLocalMetadata(state, sessionKeyId, subjectHash)
+  }, ownProps)
+}
+
+export default connect(mapStateToProps, {
+  newMetadata,
+  editMetadata,
+  updateMetadata,
+  cancelMetadataEdit,
+  loadMetadata,
+  saveMetadata
+})(MetadataEditor)

--- a/src/js/containers/MetadataEditor.js
+++ b/src/js/containers/MetadataEditor.js
@@ -6,10 +6,7 @@ import Metadata from '../components/Metadata'
 import MetadataForm from '../components/form/MetadataForm'
 import Spinner from '../components/Spinner'
 
-import { newMetadata, editMetadata, updateMetadata, cancelMetadataEdit, saveMetadata, loadMetadata } from '../actions/metadata'
-import { selectLocalMetadata, selectMetadata } from '../selectors/metadata'
-
-import { newDataset, updateDataset, loadDataset } from '../actions/dataset'
+import { newDataset, updateDataset, loadDataset, saveDataset, cancelDatasetEdit } from '../actions/dataset'
 import { selectLocalDatasetById, selectDataset } from '../selectors/dataset'
 import { selectDefaultKeyId } from '../selectors/keys'
 
@@ -77,14 +74,13 @@ class MetadataEditor extends React.Component {
     this.props.updateDataset(change)
   }
 
-  handleCancel () {
-    this.props.cancelMetadataEdit(this.props.metadata)
+  handleCancel (path) {
+    // this.props.cancelDatasetEdit(path)
   }
 
-  handleSave (meta) {
-    // this.props.saveMetadata({ keyId: this.props.sessionKeyId, subject: this.props.subjectHash, meta })
-    // // TODO - this should be in a "then" clause on saveMetadata
-    // this.props.cancelMetadataEdit(this.props.metadata)
+  handleSave (localDatasetRef) {
+    this.props.saveDataset(localDatasetRef)
+    // this.props.cancelDatasetEdit(localDatasetRef.path)
   }
 
   handleToggleHelp () {
@@ -95,14 +91,12 @@ class MetadataEditor extends React.Component {
     if (this.state.loading) {
       return <Spinner />
     } else {
-      const { dataset } = this.props.localDatasetRef
       const { showHelp } = this.state
-
       return (
         <div className='metadata editor col-md-12'>
           <a className='helpToggle right' onClick={this.handleToggleHelp}>{showHelp ? 'hide help' : 'show help' }</a>
           <MetadataForm
-            data={dataset}
+            datasetRef={this.props.localDatasetRef}
             onChange={this.handleChange}
             onCancel={this.handleCancel}
             onSubmit={this.handleSave}
@@ -122,13 +116,15 @@ MetadataEditor.propTypes = {
   newDataset: PropTypes.func.isRequired,
   loadDataset: PropTypes.func.isRequired,
   updateDataset: PropTypes.func.isRequired,
+  saveDataset: PropTypes.func.isRequired,
+  cancelDatasetEdit: PropTypes.func.isRequired
 
-  newMetadata: PropTypes.func.isRequired,
-  editMetadata: PropTypes.func.isRequired,
-  updateMetadata: PropTypes.func.isRequired,
-  cancelMetadataEdit: PropTypes.func.isRequired,
-  loadMetadata: PropTypes.func.isRequired,
-  saveMetadata: PropTypes.func
+  // newMetadata: PropTypes.func.isRequired,
+  // editMetadata: PropTypes.func.isRequired,
+  // updateMetadata: PropTypes.func.isRequired,
+  // cancelMetadataEdit: PropTypes.func.isRequired,
+  // loadMetadata: PropTypes.func.isRequired,
+  // saveMetadata: PropTypes.func
 }
 
 MetadataEditor.defaultProps = {
@@ -148,10 +144,12 @@ export default connect(mapStateToProps, {
   newDataset,
   loadDataset,
   updateDataset,
-  newMetadata,
-  editMetadata,
-  updateMetadata,
-  cancelMetadataEdit,
-  loadMetadata,
-  saveMetadata
+  saveDataset,
+  cancelDatasetEdit
+  // newMetadata,
+  // editMetadata,
+  // updateMetadata,
+  // cancelMetadataEdit,
+  // loadMetadata,
+  // saveMetadata
 })(MetadataEditor)

--- a/src/js/containers/MetadataEditor.js
+++ b/src/js/containers/MetadataEditor.js
@@ -9,6 +9,8 @@ import { newMetadata, editMetadata, updateMetadata, cancelMetadataEdit, saveMeta
 import { selectLocalMetadata, selectMetadata } from '../selectors/metadata'
 import { selectDefaultKeyId } from '../selectors/keys'
 
+import DatasetRefProps from '../propTypes/datasetRefProps'
+
 class MetadataEditor extends React.Component {
   constructor (props) {
     super(props)
@@ -27,39 +29,39 @@ class MetadataEditor extends React.Component {
     ].forEach((m) => { this[m] = this[m].bind(this) })
   }
 
-  componentWillMount () {
-    if (this.props.sessionKeyId) {
-      this.props.loadMetadata(this.props.sessionKeyId, this.props.subjectHash)
-    }
-  }
+  // componentWillMount () {
+  //   if (this.props.sessionKeyId) {
+  //     this.props.loadMetadata(this.props.sessionKeyId, this.props.subjectHash)
+  //   }
+  // }
 
-  componentWillReceiveProps (nextProps) {
-    if (nextProps.sessionKeyId != this.props.sessionKeyId) {
-      nextProps.loadMetadata(nextProps.sessionKeyId, this.props.subjectHash)
-    }
-  }
+  // componentWillReceiveProps (nextProps) {
+  //   if (nextProps.sessionKeyId != this.props.sessionKeyId) {
+  //     nextProps.loadMetadata(nextProps.sessionKeyId, this.props.subjectHash)
+  //   }
+  // }
 
   handleNew () {
-    this.props.newMetadata(this.props.sessionKeyId, this.props.subjectHash)
+    // this.props.newMetadata(this.props.sessionKeyId, this.props.subjectHash)
   }
 
   handleEdit () {
-    this.props.editMetadata(this.props.savedMetadata)
+    // this.props.editMetadata(this.props.savedMetadata)
   }
 
   handleChange (name, value) {
-    const change = { meta: Object.assign({}, this.props.metadata.meta, { [name]: value }) }
-    this.props.updateMetadata(Object.assign({}, this.props.metadata, change))
+    // const change = { meta: Object.assign({}, this.props.metadata.meta, { [name]: value }) }
+    // this.props.updateMetadata(Object.assign({}, this.props.metadata, change))
   }
 
   handleCancel () {
-    this.props.cancelMetadataEdit(this.props.metadata)
+    // this.props.cancelMetadataEdit(this.props.metadata)
   }
 
   handleSave (meta) {
-    this.props.saveMetadata({ keyId: this.props.sessionKeyId, subject: this.props.subjectHash, meta })
-    // TODO - this should be in a "then" clause on saveMetadata
-    this.props.cancelMetadataEdit(this.props.metadata)
+    // this.props.saveMetadata({ keyId: this.props.sessionKeyId, subject: this.props.subjectHash, meta })
+    // // TODO - this should be in a "then" clause on saveMetadata
+    // this.props.cancelMetadataEdit(this.props.metadata)
   }
 
   handleToggleHelp () {
@@ -67,29 +69,31 @@ class MetadataEditor extends React.Component {
   }
 
   render () {
-    const { savedMetadata, metadata, sessionKeyId } = this.props
+    const { datasetRef } = this.props
+    // const { savedMetadata, metadata, sessionKeyId } = this.props
     const { showHelp } = this.state
 
-    if (savedMetadata && !metadata) {
-      return (
-        <div className='metadata editor col-md-12'>
-          <Metadata metadata={savedMetadata.meta} />
-          {sessionKeyId ? <button className='btn btn-primary' onClick={this.handleEdit}>Edit</button> : <p><Link to='/signup'>Signup</Link> to edit metadata.</p>}
-        </div>
-      )
-    } else if (!metadata) {
-      return (
-        <div className='metadata editor col-md-12'>
-          {sessionKeyId ? <button className='btn btn-primary' onClick={this.handleNew}>Add Metadata</button> : <p><Link to='/signup'>Signup</Link> to add metadata.</p>}
-        </div>
-      )
-    }
+    // if (savedMetadata && !metadata) {
+    //   return (
+    //     <div className='metadata editor col-md-12'>
+    //       <Metadata metadata={savedMetadata.meta} />
+    //       {sessionKeyId ? <button className='btn btn-primary' onClick={this.handleEdit}>Edit</button> : <p><Link to='/signup'>Signup</Link> to edit metadata.</p>}
+    //     </div>
+    //   )
+    // }
+    // else if (!metadata) {
+    //   return (
+    //     <div className='metadata editor col-md-12'>
+    //       {sessionKeyId ? <button className='btn btn-primary' onClick={this.handleNew}>Add Metadata</button> : <p><Link to='/signup'>Signup</Link> to add metadata.</p>}
+    //     </div>
+    //   )
+    // }
 
     return (
       <div className='metadata editor col-md-12'>
         <a className='helpToggle right' onClick={this.handleToggleHelp}>{showHelp ? 'hide help' : 'show help' }</a>
         <MetadataForm
-          data={metadata.meta}
+          data={datasetRef.dataset}
           onChange={this.handleChange}
           onCancel={this.handleCancel}
           onSubmit={this.handleSave}
@@ -102,31 +106,31 @@ class MetadataEditor extends React.Component {
 }
 
 MetadataEditor.propTypes = {
-  sessionKeyId: PropTypes.string,
-  subjectHash: PropTypes.string.isRequired,
+  // sessionKeyId: PropTypes.string,
+  // subjectHash: PropTypes.string.isRequired,
 
-  metadata: PropTypes.object,
-  savedMetadata: PropTypes.object,
-
+  // metadata: PropTypes.object,
+  // savedMetadata: PropTypes.object,
+  datasetRef: DatasetRefProps,
   newMetadata: PropTypes.func.isRequired,
   editMetadata: PropTypes.func.isRequired,
   updateMetadata: PropTypes.func.isRequired,
   cancelMetadataEdit: PropTypes.func.isRequired,
   loadMetadata: PropTypes.func.isRequired,
-  saveMetadata: PropTypes.func.isRequired
+  saveMetadata: PropTypes.func
 }
 
 MetadataEditor.defaultProps = {
 }
 
 function mapStateToProps (state, ownProps) {
-  const subjectHash = ownProps.subjectHash
-  const sessionKeyId = selectDefaultKeyId(state)
+  // const subjectHash = ownProps.subjectHash
+  // const sessionKeyId = selectDefaultKeyId(state)
 
   return Object.assign({
-    sessionKeyId,
-    savedMetadata: selectMetadata(state, sessionKeyId, subjectHash),
-    metadata: selectLocalMetadata(state, sessionKeyId, subjectHash)
+    // sessionKeyId,
+    // savedMetadata: selectMetadata(state, sessionKeyId, subjectHash),
+    // metadata: selectLocalMetadata(state, sessionKeyId, subjectHash)
   }, ownProps)
 }
 

--- a/src/js/containers/MetadataEditor.js
+++ b/src/js/containers/MetadataEditor.js
@@ -9,7 +9,7 @@ import { newMetadata, editMetadata, updateMetadata, cancelMetadataEdit, saveMeta
 import { selectLocalMetadata, selectMetadata } from '../selectors/metadata'
 import { selectDefaultKeyId } from '../selectors/keys'
 
-import DatasetRefProps from '../propTypes/datasetRefProps'
+import { datasetProps } from '../propTypes/datasetRefProps'
 
 class MetadataEditor extends React.Component {
   constructor (props) {
@@ -29,11 +29,9 @@ class MetadataEditor extends React.Component {
     ].forEach((m) => { this[m] = this[m].bind(this) })
   }
 
-  // componentWillMount () {
-  //   if (this.props.sessionKeyId) {
-  //     this.props.loadMetadata(this.props.sessionKeyId, this.props.subjectHash)
-  //   }
-  // }
+  componentWillMount () {
+    this.props.newMetadata(this.props.metadata, this.props.path)
+  }
 
   // componentWillReceiveProps (nextProps) {
   //   if (nextProps.sessionKeyId != this.props.sessionKeyId) {
@@ -50,12 +48,12 @@ class MetadataEditor extends React.Component {
   }
 
   handleChange (name, value) {
-    // const change = { meta: Object.assign({}, this.props.metadata.meta, { [name]: value }) }
-    // this.props.updateMetadata(Object.assign({}, this.props.metadata, change))
+    const change = { meta: Object.assign({}, this.props.metadata, { [name]: value }) }
+    this.props.updateMetadata(Object.assign({}, this.props.metadata, change))
   }
 
   handleCancel () {
-    // this.props.cancelMetadataEdit(this.props.metadata)
+    this.props.cancelMetadataEdit(this.props.metadata)
   }
 
   handleSave (meta) {
@@ -69,7 +67,7 @@ class MetadataEditor extends React.Component {
   }
 
   render () {
-    const { datasetRef } = this.props
+    const { metadata } = this.props
     // const { savedMetadata, metadata, sessionKeyId } = this.props
     const { showHelp } = this.state
 
@@ -93,7 +91,7 @@ class MetadataEditor extends React.Component {
       <div className='metadata editor col-md-12'>
         <a className='helpToggle right' onClick={this.handleToggleHelp}>{showHelp ? 'hide help' : 'show help' }</a>
         <MetadataForm
-          data={datasetRef.dataset}
+          data={metadata}
           onChange={this.handleChange}
           onCancel={this.handleCancel}
           onSubmit={this.handleSave}
@@ -109,9 +107,9 @@ MetadataEditor.propTypes = {
   // sessionKeyId: PropTypes.string,
   // subjectHash: PropTypes.string.isRequired,
 
-  // metadata: PropTypes.object,
+  metadata: datasetProps,
   // savedMetadata: PropTypes.object,
-  datasetRef: DatasetRefProps,
+  path: PropTypes.string,
   newMetadata: PropTypes.func.isRequired,
   editMetadata: PropTypes.func.isRequired,
   updateMetadata: PropTypes.func.isRequired,

--- a/src/js/schemas.js
+++ b/src/js/schemas.js
@@ -22,6 +22,7 @@ const migrationSchema = new Schema('migrations')
 const changeSchema = new Schema('changes')
 const inviteSchema = new Schema('invites')
 const roleSchema = new Schema('roles')
+const metadataSchema = new Schema('metadata', { idAttribute: metadata => `${metadata.keyId}.${metadata.subject}` })
 
 querySchema.define({
   owner: userSchema
@@ -76,6 +77,10 @@ roleSchema.new = function (attrs) {
   return Object.assign({}, attrs, { id: 'new' })
 }
 
+metadataSchema.new = (attrs) => {
+  return Object.assign({}, attrs)
+}
+
 // Schemas for Github API responses.
 const Schemas = {
   SESSION_USER: sessionUserSchema,
@@ -95,7 +100,9 @@ const Schemas = {
   INVITE: inviteSchema,
   ROLE: roleSchema,
   ROLE_ARRAY: arrayOf(roleSchema),
-  STRUCTURED_DATA: structuredDataSchema
+  STRUCTURED_DATA: structuredDataSchema,
+  METADATA: metadataSchema,
+  METADATA_ARRAY: arrayOf(metadataSchema)
 }
 
 export default Schemas

--- a/src/js/schemas.js
+++ b/src/js/schemas.js
@@ -22,7 +22,7 @@ const migrationSchema = new Schema('migrations')
 const changeSchema = new Schema('changes')
 const inviteSchema = new Schema('invites')
 const roleSchema = new Schema('roles')
-const metadataSchema = new Schema('metadata', { idAttribute: metadata => `${metadata.keyId}.${metadata.subject}` })
+const metadataSchema = new Schema('metadata', { idAttribute: 'path' })
 
 querySchema.define({
   owner: userSchema

--- a/src/js/schemas.js
+++ b/src/js/schemas.js
@@ -50,7 +50,7 @@ changeSchema.define({
 datasetSchema.new = function (attrs) {
   return Object.assign({
     'name': 'new dataset'
-  }, attrs, { id: 'new' })
+  }, { path: 'new' }, attrs)
 }
 
 readmeSchema.new = function (attrs) {

--- a/src/js/selectors/dataset.js
+++ b/src/js/selectors/dataset.js
@@ -8,8 +8,8 @@ export function selectDataset (state, id) {
   return state.entities.datasets[id]
 }
 
-export function selectDatasetById (state, id) {
-  return state.entities.datasets[id]
+export function selectDatasetByPath (state, path) {
+  return state.entities.datasets[path]
 }
 
 export function selectUserDatasets (state, username) {

--- a/src/js/selectors/keys.js
+++ b/src/js/selectors/keys.js
@@ -1,0 +1,22 @@
+
+// default key looks for a key named "default key", falling back to any
+// available key
+export function selectDefaultKey (state) {
+  const { keys } = state.entities
+  return Object.keys(keys).map(id => keys[id]).reduce((key, a) => {
+    if (key && key.name == 'default key') {
+      return key
+    }
+    return a
+  }, {})
+}
+
+export function selectDefaultKeyId (state) {
+  const key = selectDefaultKey(state)
+  return key.sha256 || ''
+}
+
+export function selectKeys (state) {
+  const { keys } = state.entities
+  return Object.keys(keys).map(id => keys[id])
+}

--- a/src/js/selectors/metadata.js
+++ b/src/js/selectors/metadata.js
@@ -1,0 +1,19 @@
+
+export function metadataId (userId, subjectHash) {
+  return `${userId}.${subjectHash}`
+}
+
+export function selectMetadataByKey (state, key) {
+  const { metadata } = state.entities
+  return Object.keys(metadata).filter(id => metadata[id].keyId == key).map(id => metadata[id])
+}
+
+export function selectLocalMetadata (state, userId, subjectHash) {
+  if (!userId || !subjectHash) { return undefined }
+  return state.locals.metadata[metadataId(userId, subjectHash)]
+}
+
+export function selectMetadata (state, userId, subjectHash) {
+  if (!userId || !subjectHash) { return undefined }
+  return state.entities.metadata[metadataId(userId, subjectHash)]
+}

--- a/src/scss/_components.scss
+++ b/src/scss/_components.scss
@@ -3,11 +3,13 @@
 @import "components/ContextPicker";
 @import "components/DatasetDataGrid";
 @import "components/DatasetItem";
+@import "components/DateInput";
 @import "components/DownloadResultsButton";
 @import "components/Fields";
 @import "components/ForceGraph";
 @import "components/Login";
 @import "components/MainMenu";
+@import "components/MonthCalendar";
 @import "components/Navbar";
 @import "components/QueryEditor";
 @import "components/QueryItem";

--- a/src/scss/_forms.scss
+++ b/src/scss/_forms.scss
@@ -18,6 +18,7 @@
   background-image: none;
   background-clip: padding-box;
   border: $input-btn-border-width solid $input-border-color;
+  overflow: auto;
   // Note: This has no effect on <select>s in some browsers, due to the limited stylability of `<select>`s in CSS.
   @include border-radius($input-border-radius);
   @include box-shadow($input-box-shadow);

--- a/src/scss/_reboot.scss
+++ b/src/scss/_reboot.scss
@@ -347,6 +347,7 @@ input[type="month"] {
 
 textarea {
   // Textareas should really only resize vertically so they don't break their (horizontal) containers.
+  height: 200px;
   resize: vertical;
 }
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -292,7 +292,7 @@ $btn-box-shadow:                 inset 0 1px 0 rgba(255,255,255,.15), 0 1px 1px 
 $btn-active-box-shadow:          inset 0 3px 5px rgba(0,0,0,.125) !default;
 
 $btn-primary-color:              #fff !default;
-$btn-primary-bg:                 $brand-primary !default;
+$btn-primary-bg:                 #192327 !default;
 $btn-primary-border:             $btn-primary-bg !default;
 
 $btn-secondary-color:            $gray-dark !default;

--- a/src/scss/components/_DateInput.scss
+++ b/src/scss/components/_DateInput.scss
@@ -1,0 +1,12 @@
+.dateInput {
+  position: relative;
+  .calendar {
+    position: absolute;
+    top: 40px;
+    left: 0;
+    z-index: 2;
+    padding: 4px 8px;
+    box-shadow: 0 0 4px rgba(0,0,0,0.45);
+    border-radius: 3px;
+  }
+}

--- a/src/scss/components/_MonthCalendar.scss
+++ b/src/scss/components/_MonthCalendar.scss
@@ -1,0 +1,35 @@
+.calendar {
+  width: 300px;
+  background: #192327;
+  .header {
+    background: transparent;
+    box-shadow: none;
+    .backButton {
+      float: left;
+    }
+    .month {
+      text-align: center;
+    }
+    .year {
+      text-align: center;
+    }
+    .nextButton {
+      float: right;
+    }
+  }
+  table.dates {
+    width: 100%;
+    td, th {
+      text-align: center;
+      min-width: 28px;
+      min-height: 28px;
+      color: rgb(60,60,60);
+    }
+    td.current {
+      color: rgb(180,180,180);
+    }
+    td.selected {
+      color: rgb(200,0,0);
+    }
+  }
+}


### PR DESCRIPTION
Adding ability to edit metadata:
- Focusing on metadata fields such as 'Title', 'Description', etc and tabling editing schema for now
- 'Save' points to the correct endpoint to save edits