### PR TITLE
State tree refactor -> entities.datasets changed to entities.namespace and adding query history

### DIFF
--- a/app/actions/dataset.js
+++ b/app/actions/dataset.js
@@ -169,8 +169,8 @@ function createDataset (dataset) {
         data: Object.assign({}, dataset, { id: undefined, address: dataset.address })
       }
     }).then((action) => {
-      if (action.type === DATASET_CREATE_SUCCESS && action.response.entities.datasets) {
-        const ds = action.response.entities.datasets[Object.keys(action.response.entities.datasets)[0]]
+      if (action.type === DATASET_CREATE_SUCCESS && action.response.entities.namespace) {
+        const ds = action.response.entities.namespace[Object.keys(action.response.entities.namespace)[0]]
         // TODO - remove address ref
         const adr = ds.address.replace('.', '/', -1)
         const path = `/${adr}`
@@ -201,7 +201,7 @@ export function saveDataset (datasetRef) {
       }
     }).then((action) => {
       if (action.type === DATASET_SAVE_SUCCESS) {
-        const ds = action.response.entities.datasets[Object.keys(action.response.entities.datasets)[0]]
+        const ds = action.response.entities.namespace[Object.keys(action.response.entities.namespace)[0]]
         // TODO - outdated code
         const adr = ds.address.replace('.', '/', -1)
         const path = `/${adr}`

--- a/app/actions/query.js
+++ b/app/actions/query.js
@@ -116,7 +116,7 @@ export function loadQueryBySlug (slug = '', requiredFields = [], setOnLoad = fal
   }
 }
 
-export function fetchQueryPage (page = 1, pageSize = 30) {
+export function fetchQueries (page = 1, pageSize = 30) {
   return {
     [CALL_API]: {
       types: [QUERIES_REQUEST, QUERIES_SUCCESS, QUERIES_FAILURE],
@@ -129,10 +129,10 @@ export function fetchQueryPage (page = 1, pageSize = 30) {
   }
 }
 
-export function loadQueryPage (page = 1, pageSize = 30) {
+export function loadQueries (page = 1, pageSize = 30) {
   return (dispatch, getState) => {
     // TODO - check pagination
-    return dispatch(fetchQueryPage(page, pageSize))
+    return dispatch(fetchQueries(page, pageSize))
   }
 }
 

--- a/app/actions/query.js
+++ b/app/actions/query.js
@@ -64,7 +64,7 @@ export function runQuery (request) {
         types: [ QUERY_RUN_REQUEST, QUERY_RUN_SUCCESS, QUERY_RUN_FAILURE ],
         endpoint: '/run',
         method: 'POST',
-        schema: Schemas.DATASET,
+        schema: Schemas.QUERY,
         data
       }
     }).then(action => {

--- a/app/components/CodeEditor.js
+++ b/app/components/CodeEditor.js
@@ -7,7 +7,9 @@ import Base from './Base'
 
 export default class CodeEditor extends Base {
   template (css) {
-    return (<AceEditor mode='pgsql' theme='qri' {...this.props} {...this.props.editorProps} />)
+    return (<AceEditor mode='pgsql' theme='qri'
+      {...Object.assign({}, this.props.editorProps, this.props)}
+      />)
   }
 }
 

--- a/app/components/Console.js
+++ b/app/components/Console.js
@@ -117,14 +117,16 @@ export default class Console extends Base {
       top: main.top,
       left: 0,
       width: main.width,
-      height: main.height * 0.4
+      height: main.height * 0.4,
+      overflow: 'auto'
     }
 
     const bottomBox = {
       top: main.height * 0.4,
       left: 0,
       width: main.width,
-      height: main.height * 0.6
+      height: main.height * 0.6,
+      overflow: 'auto'
     }
 
     return (
@@ -140,7 +142,7 @@ export default class Console extends Base {
                 <QueryEditor bounds={topBox} name='editor' query={query} onRun={this.handleRunQuery} onDownload={this.handleDownloadQuery} onChange={this.handleEditorChange} />
               </div>,
               <div className='panel'>
-                <QueriesContainer skipLoad bounds={bottomBox} />
+                <QueriesContainer skipLoad bounds={topBox} />
               </div>
             ]}
           />

--- a/app/components/Console.js
+++ b/app/components/Console.js
@@ -38,6 +38,7 @@ export default class Console extends Base {
 
   componentWillMount () {
     loadData(this.props)
+    this.props.loadQueryPage()
     if (this.props.slug) {
       // this.props.loadQueryBySlug(this.props.slug, [], true);
     }
@@ -66,6 +67,7 @@ export default class Console extends Base {
     //   page: 1,
     // });
     this.props.runQuery(this.props.query)
+    this.props.loadQueryPage()
   }
 
   handleDownloadQuery (e) {
@@ -102,12 +104,12 @@ export default class Console extends Base {
 
   handleSelectHistoryEntry (i, query) {
     this.props.setTopPanel(0)
-    this.props.setQuery(query)
+    this.props.setQuery(query.dataset)
   }
 
   handleQuerySelect (i, query) {
     this.props.setTopPanel(0)
-    this.props.setQuery(query)
+    this.props.setQuery(query.dataset)
   }
 
   handlePeerSelect (i, peer) {
@@ -152,7 +154,7 @@ export default class Console extends Base {
                 <QueryEditor bounds={topBox} name='editor' query={query} onRun={this.handleRunQuery} onDownload={this.handleDownloadQuery} onChange={this.handleEditorChange} />
               </div>,
               <div className='panel'>
-                <List bounds={topBox} className='queryHistory list' data={queryHistory} component={QueryHistoryItem} onSelectItem={this.handleSelectHistoryEntry} />
+                <List bounds={topBox} className='queryHistory list' data={queries} component={QueryItem} onSelectItem={this.handleSelectHistoryEntry} />
               </div>
             ]}
           />
@@ -221,6 +223,7 @@ Console.propTypes = {
   setTopPanel: PropTypes.func.isRequired,
   setBottomPanel: PropTypes.func.isRequired,
   // loadDatasets: PropTypes.func.isRequired,
+  loadQueryPage: PropTypes.func.isRequired,
   loadDataset: PropTypes.func.isRequired
 }
 

--- a/app/components/Console.js
+++ b/app/components/Console.js
@@ -5,12 +5,10 @@ import DatasetDataGrid from './DatasetDataGrid'
 import TabPanel from './TabPanel'
 import QueryEditor from './QueryEditor'
 import DataTable from './DataTable'
-import List from './List'
 
-import QueryHistoryItem from './item/QueryHistoryItem'
-import QueryItem from './item/QueryItem'
 import ResultsChart from './ResultsChart'
 import DatasetsContainer from '../containers/Datasets'
+import QueriesContainer from '../containers/Queries'
 
 function loadData (props) {
   props.loadDatasets(1, 100)
@@ -27,8 +25,6 @@ export default class Console extends Base {
       'handleSetBottomPanel',
       'handleSetChartOptions',
       'handleSelectDataset',
-      'handleSelectHistoryEntry',
-      'handleQuerySelect',
       'handlePeerSelect',
       'handleLoadMoreResults'
     ].forEach((m) => { this[m] = this[m].bind(this) })
@@ -38,7 +34,7 @@ export default class Console extends Base {
 
   componentWillMount () {
     loadData(this.props)
-    this.props.loadQueryPage()
+    this.props.loadQueries()
     if (this.props.slug) {
       // this.props.loadQueryBySlug(this.props.slug, [], true);
     }
@@ -67,7 +63,7 @@ export default class Console extends Base {
     //   page: 1,
     // });
     this.props.runQuery(this.props.query)
-    this.props.loadQueryPage()
+    this.props.loadQueries()
   }
 
   handleDownloadQuery (e) {
@@ -102,16 +98,6 @@ export default class Console extends Base {
     this.props.loadDataset(dataset.id, ['schema'])
   }
 
-  handleSelectHistoryEntry (i, query) {
-    this.props.setTopPanel(0)
-    this.props.setQuery(query.dataset)
-  }
-
-  handleQuerySelect (i, query) {
-    this.props.setTopPanel(0)
-    this.props.setQuery(query.dataset)
-  }
-
   handlePeerSelect (i, peer) {
     // this doesn't do anything yet
   }
@@ -124,7 +110,7 @@ export default class Console extends Base {
   }
 
   template (css) {
-    const { queries, datasetRef, data, query, topPanelIndex, bottomPanelIndex, queryHistory, layout, peers, size, chartOptions } = this.props
+    const { datasetRef, data, query, topPanelIndex, bottomPanelIndex, queryHistory, layout, peers, size, chartOptions } = this.props
     const { main } = layout
 
     const topBox = {
@@ -154,7 +140,7 @@ export default class Console extends Base {
                 <QueryEditor bounds={topBox} name='editor' query={query} onRun={this.handleRunQuery} onDownload={this.handleDownloadQuery} onChange={this.handleEditorChange} />
               </div>,
               <div className='panel'>
-                <List bounds={topBox} className='queryHistory list' data={queries} component={QueryItem} onSelectItem={this.handleSelectHistoryEntry} />
+                <QueriesContainer skipLoad bounds={bottomBox} />
               </div>
             ]}
           />
@@ -223,7 +209,7 @@ Console.propTypes = {
   setTopPanel: PropTypes.func.isRequired,
   setBottomPanel: PropTypes.func.isRequired,
   // loadDatasets: PropTypes.func.isRequired,
-  loadQueryPage: PropTypes.func.isRequired,
+  loadQueries: PropTypes.func.isRequired,
   loadDataset: PropTypes.func.isRequired
 }
 

--- a/app/components/List.js
+++ b/app/components/List.js
@@ -9,7 +9,7 @@ function selectFunc (fn, data, i) {
 }
 
 const List = (props) => {
-  const { data, onSelectItem, className, emptyComponent } = props
+  const { data, onSelectItem, className, emptyComponent, style } = props
   if (!data || data.length === 0) {
     if (emptyComponent) {
       return (
@@ -21,7 +21,7 @@ const List = (props) => {
     return <div className={className} />
   }
   return (
-    <div className={className}>
+    <div className={className} style={style}>
       {data.map((d, i) => <props.component data={d} key={i} index={i} onSelect={selectFunc(onSelectItem, d, i)} />)}
     </div>
   )

--- a/app/components/Peers.js
+++ b/app/components/Peers.js
@@ -122,7 +122,7 @@ export default class Peers extends Base {
 Peers.propTypes = {
   searchString: PropTypes.string,
   peers: PropTypes.array.isRequired,
-  nextPage: PropTypes.number.isRequired,
+  // nextPage: PropTypes.number.isRequired,
   fetchedAll: PropTypes.bool,
   loadPeers: PropTypes.func.isRequired,
   skipLoad: PropTypes.bool

--- a/app/components/Queries.js
+++ b/app/components/Queries.js
@@ -1,0 +1,107 @@
+import React, { PropTypes } from 'react'
+import { debounce } from 'lodash'
+import { Palette, defaultPalette } from '../propTypes/palette'
+
+import Base from './Base'
+
+import List from './List'
+import QueryItem from './item/QueryItem'
+import Spinner from './Spinner'
+
+export default class Queries extends Base {
+  constructor (props) {
+    super(props)
+    // this.state = { loading: props.Queries.length === 0 };
+    this.state = { loading: false };
+
+    [
+      'onSelectQuery'
+    ].forEach((m) => { this[m] = this[m].bind(this) })
+  }
+
+  componentWillMount () {
+    if (!this.props.skipLoad) {
+      this.props.loadQueries(this.props.nextPage)
+    }
+  }
+
+  componentWillReceiveProps (nextProps) {
+    if (nextProps.Queries.length > 0 && this.props.Queries.length === 0) {
+      this.setState({ loading: false })
+    }
+  }
+
+  onSelectQuery (i, query) {
+    this.props.setTopPanel(0)
+    this.props.setQuery(query.dataset)
+  }
+
+  handleLoadNextPage () {
+    this.props.loadQueries(this.props.nextPage)
+  }
+
+  template (css) {
+    const { loading } = this.state
+    const { queries, searchString, palette, bounds } = this.props
+    let height = bounds.height - 57
+    bounds.height = height
+    if (loading) {
+      return (
+        <div className={css('wrap')}>
+          <Spinner />
+        </div>
+      )
+    }
+
+    return (
+      <div className={css('wrap')}>
+        <List
+          data={queries}
+          component={QueryItem}
+          onSelectItem={this.onSelectQuery}
+          emptyComponent={<p>No Queries</p>}
+          palette={palette}
+          style={bounds}
+          />
+      </div>
+    )
+  }
+
+  styles (props) {
+    const { palette } = this.props
+
+    return {
+      wrap: {
+        paddingLeft: 20,
+        paddingRight: 20
+      },
+      searchBox: {
+        display: 'inline-block',
+        width: '50%',
+        fontSize: '1rem',
+        lineHeight: '1.25',
+        color: '#55595c',
+        backgroundColor: '#fff',
+        border: '0.5px solid rgba(0, 0, 0, 0.15)',
+        overflow: 'auto',
+        borderRadius: '0.25rem',
+        marginBottom: 10,
+        paddingLeft: 8
+      }
+    }
+  }
+}
+
+Queries.propTypes = {
+  queries: PropTypes.array.isRequired,
+  nextPage: PropTypes.number.isRequired,
+  fetchedAll: PropTypes.bool,
+  loadQueries: PropTypes.func.isRequired,
+  skipLoad: PropTypes.bool,
+  palette: Palette
+}
+
+Queries.defaultProps = {
+  skipLoad: false,
+  palette: defaultPalette
+}

--- a/app/components/Queries.js
+++ b/app/components/Queries.js
@@ -43,6 +43,7 @@ export default class Queries extends Base {
   template (css) {
     const { loading } = this.state
     const { queries, searchString, palette, bounds } = this.props
+    // 57 is the run button height, should these things be saved and pulled from the state tree?
     let height = bounds.height - 57
     bounds.height = height
     if (loading) {

--- a/app/components/QueryEditor.js
+++ b/app/components/QueryEditor.js
@@ -7,7 +7,6 @@ import { datasetCompleter } from '../ace/completer/datasets'
 export default class QueryEditor extends Base {
   template (css) {
     const { name, query, onDownload, onRun, onChange, bounds } = this.props
-
     return (
       <div className={css('wrap')}>
         <CodeEditor
@@ -15,7 +14,7 @@ export default class QueryEditor extends Base {
           value={query.queryString}
           completers={[datasetCompleter]}
           width={`${bounds.width - 40}px`}
-          height={`${bounds.height - 80}px`}
+          height={`${bounds.height - 95}px`}
           onChange={value => onChange({ queryString: value, address: query.address })}
         // TODO - reenable when adding back completion
         // setOptions={{

--- a/app/components/Stylesheet.js
+++ b/app/components/Stylesheet.js
@@ -30,8 +30,8 @@ const Stylesheet = () => {
             Phasellus cursus, felis eu aliquet maximus, neque lorem egestas est, eu varius nulla sapien vitae tellus.</p>
           </div>
           <div className='col-md-6'>
-            <ValidInput type='text' name='input' label='valid input' value='input' showValidation={false} validation='blah' />
-            <ValidInput type='text' name='input' label='invalid input' value='input' showValidation error='blah' />
+            <ValidInput type='text' name='input' label='valid input' value='input' showValidation={false} validation='blah' onChange={() => undefined} />
+            <ValidInput type='text' name='input' label='invalid input' value='input' showValidation error='blah' onChange={() => undefined} />
             <button className='btn btn-primary'>Primary Button</button>
           </div>
         </div>

--- a/app/components/TabPanel.js
+++ b/app/components/TabPanel.js
@@ -11,7 +11,6 @@ export default class TabPanel extends Base {
   template (css) {
     const { index, labels = [], components, onSelectPanel } = this.props
     const component = components[index]
-
     return (
       <div>
         <div className={css('header')}>

--- a/app/components/item/QueryItem.js
+++ b/app/components/item/QueryItem.js
@@ -1,12 +1,11 @@
 import React, { PropTypes } from 'react'
 
 const QueryItem = ({ data, onSelect }) => {
-  const query = data
   return (
     <div className='queryItem' onClick={onSelect}>
       <hr />
-      <h5 className='title'>{query.name || query.dataset.queryString || 'unnamed query'}</h5>
-      <p><i>{query.path}</i></p>
+      <h5 className='title'>{data.name || data.dataset.queryString || 'unnamed query'}</h5>
+      <p><i>{data.path}</i></p>
     </div>
   )
 }

--- a/app/components/item/QueryItem.js
+++ b/app/components/item/QueryItem.js
@@ -1,11 +1,12 @@
 import React, { PropTypes } from 'react'
 
 const QueryItem = ({ data, onSelect }) => {
+  const query = data
   return (
     <div className='queryItem' onClick={onSelect}>
       <hr />
-      <h5 className='title'>{data.headline || data.name || 'unnamed query'}</h5>
-      <small>{data.statement}</small>
+      <h5 className='title'>{query.name || query.dataset.queryString || 'unnamed query'}</h5>
+      <small>{query.path}</small>
     </div>
   )
 }

--- a/app/components/item/QueryItem.js
+++ b/app/components/item/QueryItem.js
@@ -6,7 +6,7 @@ const QueryItem = ({ data, onSelect }) => {
     <div className='queryItem' onClick={onSelect}>
       <hr />
       <h5 className='title'>{query.name || query.dataset.queryString || 'unnamed query'}</h5>
-      <small>{query.path}</small>
+      <p><i>{query.path}</i></p>
     </div>
   )
 }

--- a/app/containers/Console.js
+++ b/app/containers/Console.js
@@ -8,7 +8,7 @@ import Console from '../components/Console'
 
 const ConsoleContainer = connect(
   (state, ownProps) => {
-    const datasetRef = state.entities.namespace[state.console.queryResults]
+    const datasetRef = state.entities.queries[state.console.queryResults]
     let data
     if (datasetRef) {
       data = state.entities.data[datasetRef.path] && state.entities.data[datasetRef.path].data
@@ -19,7 +19,7 @@ const ConsoleContainer = connect(
     }
     const size = state.layout.size ? state.layout.size : ''
     return Object.assign({}, {
-      queries: Object.keys(state.entities.queries).map(key => state.entities.queries[key]),
+      queries: Object.keys(state.entities.queries).map(key => state.entities.queries[key]).reverse(),
       datasets: Object.keys(state.entities.namespace).map(key => state.entities.namespace[key]),
       queryHistory: state.session.history,
       layout: state.layout,

--- a/app/containers/Console.js
+++ b/app/containers/Console.js
@@ -8,7 +8,7 @@ import Console from '../components/Console'
 
 const ConsoleContainer = connect(
   (state, ownProps) => {
-    const datasetRef = state.entities.datasets[state.console.queryResults]
+    const datasetRef = state.entities.namespace[state.console.queryResults]
     let data
     if (datasetRef) {
       data = state.entities.data[datasetRef.path] && state.entities.data[datasetRef.path].data
@@ -20,7 +20,7 @@ const ConsoleContainer = connect(
     const size = state.layout.size ? state.layout.size : ''
     return Object.assign({}, {
       queries: Object.keys(state.entities.queries).map(key => state.entities.queries[key]),
-      datasets: Object.keys(state.entities.datasets).map(key => state.entities.datasets[key]),
+      datasets: Object.keys(state.entities.namespace).map(key => state.entities.namespace[key]),
       queryHistory: state.session.history,
       layout: state.layout,
       chartOptions: state.console.chartOptions,

--- a/app/containers/Console.js
+++ b/app/containers/Console.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux'
 
-import { setQuery, runQuery, loadQueryBySlug, loadQueryPage } from '../actions/query'
+import { setQuery, runQuery, loadQueryBySlug, loadQueries } from '../actions/query'
 import { setTopPanel, setBottomPanel, setChartOptions, resetChartOptions } from '../actions/console'
 import { loadDatasets, loadDataset } from '../actions/dataset'
 
@@ -32,7 +32,7 @@ const ConsoleContainer = connect(
   }, {
     setQuery,
     runQuery,
-    loadQueryPage,
+    loadQueries,
     loadQueryBySlug,
 
     setTopPanel,

--- a/app/containers/Queries.js
+++ b/app/containers/Queries.js
@@ -1,0 +1,27 @@
+import { connect } from 'react-redux'
+
+import { loadQueries, setQuery } from '../actions/query'
+import { setTopPanel } from '../actions/console'
+import { selectQueries, selectQueriesPageCount, selectQueriesFetchedAll, selectQueriesIsFetching } from '../selectors/query'
+
+import Queries from '../components/Queries'
+
+const QueriesContainer = connect(
+  (state, ownProps) => {
+    const pagination = state.pagination.popularQueries
+    const paginationSection = ''
+    const searchString = ''
+    return Object.assign({
+      queries: selectQueries(state, paginationSection, searchString),
+      loading: selectQueriesIsFetching(state, paginationSection, searchString),
+      nextPage: selectQueriesPageCount(state, paginationSection, searchString) + 1,
+      fetchedAll: selectQueriesFetchedAll(state, paginationSection, searchString)
+    }, ownProps)
+  }, {
+    loadQueries,
+    setTopPanel,
+    setQuery
+  }
+)(Queries, 'Queries')
+
+export default QueriesContainer

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -21,7 +21,7 @@ const initialEntitiesState = {
   users: {},
   roles: {},
 
-  datasets: {},
+  namespace: {},
   data: {},
   readmes: {},
   changes: {},

--- a/app/reducers/locals.js
+++ b/app/reducers/locals.js
@@ -3,7 +3,7 @@ import * as ActionTypes from '../actions/app'
 const initialState = {
   invites: {},
   queries: {},
-  datasets: {},
+  namespace: {},
   migrations: {},
   changes: {},
   roles: {}

--- a/app/reducers/pagination.js
+++ b/app/reducers/pagination.js
@@ -24,8 +24,8 @@ import {
 
 // Updates the pagination data for different actions.
 const pagination = combineReducers({
-  queryHistory: paginate({
-    mapActionToKey: action => 'queryHistory',
+  popularQueries: paginate({
+    mapActionToKey: action => 'popularQueries',
     types: [
       QUERIES_REQUEST,
       QUERIES_SUCCESS,

--- a/app/reducers/pagination.js
+++ b/app/reducers/pagination.js
@@ -24,8 +24,8 @@ import {
 
 // Updates the pagination data for different actions.
 const pagination = combineReducers({
-  popularQueries: paginate({
-    mapActionToKey: action => 'popularQueries',
+  queryHistory: paginate({
+    mapActionToKey: action => 'queryHistory',
     types: [
       QUERIES_REQUEST,
       QUERIES_SUCCESS,

--- a/app/schemas.js
+++ b/app/schemas.js
@@ -13,7 +13,7 @@ import { Schema, arrayOf } from 'normalizr'
 const sessionUserSchema = new Schema('session')
 const sshKeySchema = new Schema('ssh_keys', { idAttribute: 'sha256' })
 const userSchema = new Schema('users')
-const datasetSchema = new Schema('datasets', { idAttribute: 'path' })
+const datasetSchema = new Schema('namespace', { idAttribute: 'path' })
 const readmeSchema = new Schema('readmes', { idAttribute: 'address' })
 const querySchema = new Schema('queries')
 // const resultSchema = new Schema('results', { idAttribute : (result) => 'result' });

--- a/app/schemas.js
+++ b/app/schemas.js
@@ -15,7 +15,7 @@ const sshKeySchema = new Schema('ssh_keys', { idAttribute: 'sha256' })
 const userSchema = new Schema('users')
 const datasetSchema = new Schema('namespace', { idAttribute: 'path' })
 const readmeSchema = new Schema('readmes', { idAttribute: 'address' })
-const querySchema = new Schema('queries')
+const querySchema = new Schema('queries', { idAttribute: 'path' })
 // const resultSchema = new Schema('results', { idAttribute : (result) => 'result' });
 const structuredDataSchema = new Schema('data', { idAttribute: 'path' })
 const migrationSchema = new Schema('migrations')

--- a/app/selectors/dataset.js
+++ b/app/selectors/dataset.js
@@ -8,17 +8,17 @@ export function addressPath (address) {
 }
 
 export function selectDataset (state, id) {
-  return state.entities.datasets[id]
+  return state.entities.namespace[id]
 }
 
 export function selectDatasetByPath (state, path) {
-  return state.entities.datasets[path]
+  return state.entities.namespace[path]
 }
 
 export function selectUserDatasets (state, username) {
-  const { datasets } = state.entities
-  return Object.keys(datasets).reduce((sets, id) => {
-    const ds = datasets[id]
+  const { namespace } = state.entities
+  return Object.keys(namespace).reduce((sets, id) => {
+    const ds = namespace[id]
     if (ds.address.split('.')[0] === username) {
       sets.push(ds)
     }
@@ -27,33 +27,33 @@ export function selectUserDatasets (state, username) {
 }
 
 export function selectDatasetByAddress (state, address) {
-  const { datasets } = state.entities
-  const id = Object.keys(datasets).find(id => (datasets[id].address === address))
+  const { namespace } = state.entities
+  const id = Object.keys(namespace).find(id => (namespace[id].address === address))
   if (!id) { return undefined }
-  if (datasets[id].default_query) {
+  if (namespace[id].default_query) {
     return Object.assign({},
-      datasets[id],
-      { default_query: selectQueryById(state, datasets[id].default_query) })
+      namespace[id],
+      { default_query: selectQueryById(state, namespace[id].default_query) })
   } else {
-    return datasets[id]
+    return namespace[id]
   }
 }
 
 export function selectDatasetByQueryString (state, queryString) {
-  const { datasets } = state.entities
-  // if (datasets[id].default_query) {
+  const { namespace } = state.entities
+  // if (namespace[id].default_query) {
   //   return Object.assign({},
-  //     datasets[id],
-  //     { default_query : selectQueryById(state, datasets[id].default_query) });
+  //     namespace[id],
+  //     { default_query : selectQueryById(state, namespace[id].default_query) });
   // } else {
-  //   return datasets[id]
+  //   return namespace[id]
   // }
-  const path = Object.keys(datasets).find(path => {
-    console.log(datasets[path].dataset.queryString, queryString)
-    return datasets[path].dataset.queryString === queryString
+  const path = Object.keys(namespace).find(path => {
+    console.log(namespace[path].dataset.queryString, queryString)
+    return namespace[path].dataset.queryString === queryString
   })
   // if (!path) { return undefined; }
-  return datasets[path]
+  return namespace[path]
 }
 
 export function selectDatasetData (state, path) {
@@ -66,18 +66,18 @@ export function selectDatasetReadme (state, address) {
 }
 
 export function selectDatasetDescendants (state, address) {
-  const { datasets } = state.entities
-  return Object.keys(datasets).filter((adr) => adr.includes(address) && adr !== address).map(adr => { return datasets[adr] })
+  const { namespace } = state.entities
+  return Object.keys(namespace).filter((adr) => adr.includes(address) && adr !== address).map(adr => { return namespace[adr] })
 }
 
 export function selectLocalDatasetByAddress (state, address) {
-  const { datasets } = state.locals
-  const id = Object.keys(datasets).find(id => (datasets[id].address === address))
-  return id ? datasets[id] : undefined
+  const { namespace } = state.locals
+  const id = Object.keys(namespace).find(id => (namespace[id].address === address))
+  return id ? namespace[id] : undefined
 }
 
 export function selectLocalDatasetById (state, id) {
-  return state.locals.datasets[id]
+  return state.locals.namespace[id]
 }
 
 export function selectDatasetChanges (state, datasetId) {
@@ -86,16 +86,16 @@ export function selectDatasetChanges (state, datasetId) {
 }
 
 export function selectAllDatasets (state) {
-  const { datasets } = state.entities
-  return Object.keys(datasets).map(id => datasets[id]).sort((a, b) => {
+  const { namespace } = state.entities
+  return Object.keys(namespace).map(id => namespace[id]).sort((a, b) => {
     return (a.address === b.address) ? 0 : ((a.address < a.address)) ? -1 : 1
   })
 }
 
 // generate an object-of-objects that maps the address space without overlaps
 export function selectDatasetTree (state) {
-  const { datasets } = state.entities
-  return Object.keys(datasets).reduce((acc, adr, i) => {
+  const { namespace } = state.entities
+  return Object.keys(namespace).reduce((acc, adr, i) => {
     adr.split('.').reduce((acc, el) => {
       acc[el] || (acc[el] = { })
       return acc[el]
@@ -139,8 +139,8 @@ export function selectDatasets (state, section, node) {
     section = usersDatasetsSection
     node = usersDatasetsNode
   }
-  const { datasets } = state.entities
-  return selectDatasetsIds(state, section, node).map(id => datasets[id])
+  const { namespace } = state.entities
+  return selectDatasetsIds(state, section, node).map(id => namespace[id])
 }
 
 export function selectDatasetsIsFetching (state, section, node) {

--- a/app/selectors/query.js
+++ b/app/selectors/query.js
@@ -1,5 +1,7 @@
-
 import { selectUserByUsername } from './user'
+
+const usersQueriesSection = 'popularQueries'
+const usersQueriesNode = 'popularQueries'
 
 export function selectQueryById (state, id) {
   return state.entities.queries[id]
@@ -53,4 +55,45 @@ export function selectAllQueries (state) {
   return Object.keys(queries).map(id => queries[id]).sort((a, b) => {
     return (a.address === b.address) ? 0 : ((a.address < a.address)) ? -1 : 1
   })
+}
+
+export function selectQueries (state, section, node) {
+  if (!section && !node) {
+    section = usersQueriesSection
+    node = usersQueriesNode
+  }
+  const { queries } = state.entities
+  return selectQueriesIds(state, section, node).map(id => queries[id])
+}
+
+export function selectQueriesIsFetching (state, section, node) {
+  if (!section && !node) {
+    section = usersQueriesSection
+    node = usersQueriesNode
+  }
+  return (state.pagination[section] && state.pagination[section][node]) ? state.pagination[section][node].isFetching : false
+}
+
+export function selectQueriesPageCount (state, section, node) {
+  if (!section && !node) {
+    section = usersQueriesSection
+    node = usersQueriesNode
+  }
+  return (state.pagination[section] && state.pagination[section][node]) ? state.pagination[section][node].pageCount : 0
+}
+
+export function selectQueriesFetchedAll (state, section, node) {
+  if (!section && !node) {
+    section = usersQueriesSection
+    node = usersQueriesNode
+  }
+  return (state.pagination[section] && state.pagination[section][node]) ? state.pagination[section][node].fetchedAll : false
+}
+
+export function selectQueriesIds (state, section, node) {
+  if (!section && !node) {
+    section = usersQueriesSection
+    node = usersQueriesNode
+  }
+  return (state.pagination[section] && state.pagination[section][node]) ? state.pagination[section][node].ids : []
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -181,7 +181,7 @@ anymatch@^1.3.0:
     micromatch "^2.1.5"
     normalize-path "^2.0.0"
 
-aphrodite-simple@^0.4.1:
+aphrodite-simple@0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/aphrodite-simple/-/aphrodite-simple-0.4.1.tgz#ceac064e5ecb2bca2b80a3bf84f172729bc926d8"
   dependencies:


### PR DESCRIPTION
To reflect the backend codebase and to make room for queries as a separate concept from datasets, `state.entities.datasets` is now `state.entities.namespace`
Queries are stored in `state.entities.queries` + this is where were we pull to populate our history tab
**realized that this doesn't take into account pagination**

Known bug: *api calls to search not returning anything*