### PR TITLE
Need feedback when you add a dataset from a peer

### DIFF
--- a/app/actions/app.js
+++ b/app/actions/app.js
@@ -4,9 +4,10 @@ import {
   APP_SHOW_MODAL,
   APP_HIDE_MODAL,
   RESET_ERROR_MESSAGE,
-  APP_SET_MESSAGE,
+  SET_MESSAGE,
   RESET_MESSAGE,
-  REMOVE_MODEL
+  REMOVE_MODEL,
+  SET_SEARCH
 } from '../constants/app'
 
 export function toggleMenu () {
@@ -47,18 +48,15 @@ export function resetErrorMessage () {
 }
 
 export function setMessage (message) {
-  console.log('in setMessage')
-  console.log(message)
-  console.log(APP_SET_MESSAGE)
   return {
-    type: APP_SET_MESSAGE,
+    type: SET_MESSAGE,
     message: message
   }
 }
 
 export function resetMessage () {
   return {
-    type: APP_SET_MESSAGE,
+    type: SET_MESSAGE,
     message: ''
   }
 }
@@ -72,7 +70,6 @@ export function removeModel (schema, id) {
   }
 }
 
-export const SET_SEARCH = 'SET_SEARCH'
 export function setSearch (search) {
   return {
     type: SET_SEARCH,

--- a/app/actions/app.js
+++ b/app/actions/app.js
@@ -4,7 +4,7 @@ import {
   APP_SHOW_MODAL,
   APP_HIDE_MODAL,
   RESET_ERROR_MESSAGE,
-  SET_MESSAGE,
+  APP_SET_MESSAGE,
   RESET_MESSAGE,
   REMOVE_MODEL
 } from '../constants/app'
@@ -47,15 +47,19 @@ export function resetErrorMessage () {
 }
 
 export function setMessage (message) {
+  console.log('in setMessage')
+  console.log(message)
+  console.log(APP_SET_MESSAGE)
   return {
-    type: SET_MESSAGE,
-    message
+    type: APP_SET_MESSAGE,
+    message: message
   }
 }
 
 export function resetMessage () {
   return {
-    type: RESET_MESSAGE
+    type: APP_SET_MESSAGE,
+    message: ''
   }
 }
 

--- a/app/actions/dataset.js
+++ b/app/actions/dataset.js
@@ -156,7 +156,7 @@ export function fetchDatasetData (path, page = 1, pageSize = 100) {
   }
 }
 
-export function loadDatasetData (path, page = 1, pageSize = 100, callback) {
+export function loadDatasetData (path, callback, page = 1, pageSize = 100) {
   return (dispatch) => {
     // const dataset = selectDatasetByAddress(getState(), address)
     // if (dataset.schema != null) {
@@ -427,13 +427,23 @@ export function runDatasetSearch (searchString, page = 1, pageSize = 50) {
 }
 
 export function addDataset (path, name) {
-  return {
-    [CALL_API]: {
-      types: [DATASET_ADD_REQUEST, DATASET_ADD_SUCCESS, DATASET_ADD_FAILURE],
-      endpoint: `/add${path}?name=${name}`,
-      method: 'POST',
-      data: {},
-      schema: Schemas.DATASET
-    }
+  return (dispatch) => {
+    return dispatch({
+      [CALL_API]: {
+        types: [DATASET_ADD_REQUEST, DATASET_ADD_SUCCESS, DATASET_ADD_FAILURE],
+        endpoint: `/add${path}?name=${name}`,
+        method: 'POST',
+        data: {},
+        schema: Schemas.DATASET
+      }
+    }).then(action => {
+      if (action.type === DATASET_ADD_SUCCESS) {
+        alert('Peer dataset added to your local datasets!')
+        loadDatasets()
+      } else {
+        console.log(`DATASET_ADD_FAILURE: ${action.error}`)
+        alert('Error adding this dataset to your local datasets')
+      }
+    })
   }
 }

--- a/app/actions/dataset.js
+++ b/app/actions/dataset.js
@@ -439,7 +439,6 @@ export function addDataset (path, name) {
     }).then(action => {
       if (action.type === DATASET_ADD_SUCCESS) {
         alert('Peer dataset added to your local datasets!')
-        loadDatasets()
       } else {
         console.log(`DATASET_ADD_FAILURE: ${action.error}`)
         alert('Error adding this dataset to your local datasets')

--- a/app/actions/query.js
+++ b/app/actions/query.js
@@ -80,7 +80,7 @@ export function runQuery (request, callback) {
         callback(action.error)
       } else if (action.type === QUERY_RUN_SUCCESS) {
         dispatch(setQueryResults(action.response.result))
-        dispatch(loadDatasetData(action.response.result, 1, 100, callback))
+        dispatch(loadDatasetData(action.response.result, callback))
       }
 
       return null

--- a/app/actions/query.js
+++ b/app/actions/query.js
@@ -76,8 +76,6 @@ export function runQuery (request, callback) {
       }
     }).then(action => {
       // Dismiss errors after 3.8 seconds
-      console.log('in runQuery')
-      console.log(action.type)
       if (action.type === QUERY_RUN_FAILURE) {
         callback(action.error)
       } else if (action.type === QUERY_RUN_SUCCESS) {

--- a/app/components/Console.js
+++ b/app/components/Console.js
@@ -68,7 +68,6 @@ export default class Console extends Base {
     //   query: this.props.query.,
     //   page: 1,
     // });
-    console.log(this.props.query)
     this.props.setLoadingData(true)
     this.props.resetQueryResults()
     this.props.runQuery(this.props.query, (error) => {

--- a/app/components/Dataset.js
+++ b/app/components/Dataset.js
@@ -59,14 +59,26 @@ export default class Dataset extends Base {
     }
   }
 
-  handleDownloadDataset (e) {
-    e.preventDefault()
-    this.props.downloadDataset(this.props.address)
+  handleDownloadDataset (path, peer) {
+    if (!peer) {
+      return (e) => {
+        e.preventDefault()
+        this.props.downloadDataset(path)
+      }
+    } else {
+      return undefined
+    }
   }
 
-  handleDeleteDataset () {
-    if (confirm('are you sure you want to delete this dataset?')) {
-      this.props.deleteDataset(this.props.datasetRef.path, '/')
+  handleDeleteDataset (path, peer) {
+    if (!peer) {
+      return (path) => {
+        if (confirm('are you sure you want to delete this dataset?')) {
+          this.props.deleteDataset(path, '/')
+        }
+      }
+    } else {
+      return undefined
     }
   }
 
@@ -85,7 +97,9 @@ export default class Dataset extends Base {
   }
 
   handleAddDataset (path, name, peer) {
-    return peer ? () => this.props.addDataset(path, name) : undefined
+    return peer ? () => {
+      this.props.addDataset(path, name)
+    } : undefined
   }
 
   changeTabIndex (index) {
@@ -93,8 +107,12 @@ export default class Dataset extends Base {
     this.setState({ tabIndex: index })
   }
 
-  handleEditMetadata (path) {
-    return () => this.props.history.push(`/edit/${path.slice(6, -13)}`)
+  handleEditMetadata (path, peer) {
+    if (!peer) {
+      return () => this.props.history.push(`/edit/${path.slice(6, -13)}`)
+    } else {
+      return undefined
+    }
   }
 
   handleSetLoadingData (loading) {
@@ -150,7 +168,7 @@ export default class Dataset extends Base {
   }
 
   template (css) {
-    const { datasetRef, readme, peer } = this.props
+    const { datasetRef, readme } = this.props
     // const path = "/" + address.replace(".", "/", -1)
     // const hasData = (dataset && (dataset.url || dataset.file || dataset.data));
     // TODO hasData is assigned a value but never used, consider depreciation
@@ -163,11 +181,11 @@ export default class Dataset extends Base {
       )
     }
 
-    const { dataset, path, name } = datasetRef
+    const { dataset, path, name, peer } = datasetRef
     const { tabIndex } = this.state
     return (
       <div className={css('wrap')} >
-        <DatasetHeader datasetRef={datasetRef} onClickDelete={this.handleDeleteDataset} onClickExport={this.handleDownloadDataset} onClickEdit={this.handleEditMetadata(path)} onGoBack={this.handleGoBack} onClickAdd={this.handleAddDataset(path, name, peer)} />
+        <DatasetHeader datasetRef={datasetRef} onClickDelete={this.handleDeleteDataset(path, peer)} onClickExport={this.handleDownloadDataset(path, peer)} onClickEdit={this.handleEditMetadata(path, peer)} onGoBack={this.handleGoBack} onClickAdd={this.handleAddDataset(path, name, peer)} peer={peer} />
         <TabPanel
           index={tabIndex}
           labels={['Info', 'Fields', 'Data', 'Queries', 'History']}

--- a/app/components/DatasetDataGrid.js
+++ b/app/components/DatasetDataGrid.js
@@ -111,7 +111,7 @@ DatasetDataGrid.propTypes = {
   onLoadMore: PropTypes.func,
   minHeight: PropTypes.number,
   loading: PropTypes.bool.isRequired,
-  error: PropTypes.string
+  error: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
 }
 
 DatasetDataGrid.defaultProps = {

--- a/app/components/DatasetHeader.js
+++ b/app/components/DatasetHeader.js
@@ -9,7 +9,7 @@ import Base from './Base'
 
 export default class DatasetHeader extends Base {
   template (css) {
-    const { datasetRef, onClickExport, onClickEdit, onClickDelete, onClickAdd, onGoBack } = this.props
+    const { datasetRef, onClickExport, onClickEdit, onClickDelete, onClickAdd, onGoBack, peer } = this.props
     const { name, path, dataset } = datasetRef
     return (
       <div className='wrapper'>
@@ -21,7 +21,7 @@ export default class DatasetHeader extends Base {
           onClickAdd={onClickAdd}
         />
         <div className=''>
-          <DatasetItem data={datasetRef} link={false} />
+          <DatasetItem data={datasetRef} link={false} peer={peer} />
         </div>
       </div>
     )
@@ -42,7 +42,8 @@ DatasetHeader.propTypes = {
   onClickEdit: PropTypes.func,
   onClickDelete: PropTypes.func,
   onClickAdd: PropTypes.func,
-  palette: Palette
+  palette: Palette,
+  peer: PropTypes.bool
 }
 
 DatasetHeader.defaultProps = {

--- a/app/components/Datasets.js
+++ b/app/components/Datasets.js
@@ -47,12 +47,9 @@ export default class Datasets extends Base {
   }
 
   handleLoadDatasetsError (error) {
-    console.log('in handleLoadDatasetsError')
     if (error) {
-      console.log('in error handleloaddatasets error')
       this.setState({message: 'There was an error loading your Datasets. Please try again by refreshing the page.', error: true})
     } else {
-      console.log('in else handleloaddatasets error')
       this.setState({message: 'No Datasets', error: false})
     }
   }

--- a/app/components/Peer.js
+++ b/app/components/Peer.js
@@ -33,7 +33,7 @@ export default class Peer extends Base {
     if (!this.props.namespace.length) {
       this.props.loadPeerNamespace(this.props.path, this.props.nextPage, 30, (error) => {
         let message = 'Peer has no Datasets'
-        if (error && error.toString() === 'routing: not found') {
+        if (error && (error.toString() === 'routing: not found' || error.toString() === 'error sending message to peer: routing: not found')) {
           message = 'Peer is not currently connected'
         } else if (error) {
           message = 'Error loading Peer Datasets. Check console for more info.'

--- a/app/components/item/DatasetItem.js
+++ b/app/components/item/DatasetItem.js
@@ -15,7 +15,7 @@ export default class DatasetItem extends Base {
       return (
         <div className='dataset item' >
           <Link to={{pathname: `/dataset/${path}`}} >
-            <b className={css('name')}>{data.name || <i>unnamed dataset</i>}</b>
+            { data.peer ? undefined : <b className={css('name')}>✔ &nbsp;</b>}<b className={css('name')}>{data.name || <i>unnamed dataset</i>}</b>
             <h3>{(data.dataset && data.dataset.title) || <i>untitled dataset</i>}</h3>
           </Link>
           <p className={css('path')}>{data.path}</p>
@@ -24,7 +24,7 @@ export default class DatasetItem extends Base {
     } else {
       return (
         <div className='dataset item' >
-          <b className={css('name')}>{data.name || <i>unnamed dataset</i>}</b>
+          { data.peer ? undefined : <b className={css('name')}>✔ &nbsp;</b>}<b className={css('name')}>{data.name || <i>unnamed dataset</i>}</b>
           <h3>{(data.dataset && data.dataset.title) || <i>untitled dataset</i>}</h3>
           <p className={css('path')}>{data.path}</p>
           {/* <ul>

--- a/app/components/item/DatasetItem.js
+++ b/app/components/item/DatasetItem.js
@@ -15,7 +15,7 @@ export default class DatasetItem extends Base {
       return (
         <div className='dataset item' >
           <Link to={{pathname: `/dataset/${path}`}} >
-            { data.peer ? undefined : <b className={css('name')}>✔ &nbsp;</b>}<b className={css('name')}>{data.name || <i>unnamed dataset</i>}</b>
+            <b className={css('name')}>{data.name || <i>unnamed dataset</i>}</b>{ data.peer ? undefined : <b className={css('name')}>&nbsp;✔</b>}
             <h3>{(data.dataset && data.dataset.title) || <i>untitled dataset</i>}</h3>
           </Link>
           <p className={css('path')}>{data.path}</p>
@@ -24,7 +24,7 @@ export default class DatasetItem extends Base {
     } else {
       return (
         <div className='dataset item' >
-          { data.peer ? undefined : <b className={css('name')}>✔ &nbsp;</b>}<b className={css('name')}>{data.name || <i>unnamed dataset</i>}</b>
+          <b className={css('name')}>{data.name || <i>unnamed dataset</i>}</b>{ data.peer ? undefined : <b className={css('name')}>&nbsp;✔</b>}
           <h3>{(data.dataset && data.dataset.title) || <i>untitled dataset</i>}</h3>
           <p className={css('path')}>{data.path}</p>
           {/* <ul>

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -12,7 +12,7 @@ import App from '../components/App'
 const AppContainer = connect(
   (state, ownProps) => {
     return {
-      message: state.message,
+      message: state.app.message,
       errorMessage: state.errorMessage,
       user: selectSessionUser(state),
       showMenu: state.app.showMenu,

--- a/app/containers/Dataset.js
+++ b/app/containers/Dataset.js
@@ -1,7 +1,7 @@
 /* globals confirm */
 import { connect } from 'react-redux'
 
-import { downloadDataset, deleteDataset, loadDatasetData, addDataset } from '../actions/dataset'
+import { downloadDataset, deleteDataset, loadDatasetData, addDataset, loadDatasets } from '../actions/dataset'
 import { setQuery, runQuery, downloadQuery } from '../actions/query'
 
 import { selectDataset, selectDatasetData, selectDatasetDataIsFetching } from '../selectors/dataset'
@@ -13,11 +13,9 @@ const DatasetContainer = connect(
     // console.log(ownProps.match.params)
     // const path = ownProps.path || `/${ownProps.params.splat}`
     const path = `/ipfs/${ownProps.match.params.id}/dataset.json`
-    const { datasetRef, peer } = selectDataset(state, path)
     return Object.assign({
       path,
-      datasetRef,
-      peer,
+      datasetRef: selectDataset(state, path),
       data: selectDatasetData(state, path),
       history: ownProps.history,
       goBack: ownProps.history.goBack
@@ -29,7 +27,8 @@ const DatasetContainer = connect(
     downloadDataset,
     deleteDataset,
     addDataset,
-    loadDatasetData
+    loadDatasetData,
+    loadDatasets
   }
 )(Dataset, 'Dataset')
 

--- a/app/containers/Datasets.js
+++ b/app/containers/Datasets.js
@@ -16,7 +16,7 @@ const DatasetsContainer = connect(
       datasets: selectDatasets(state, paginationSection, searchString),
       noDatasets: selectNoDatasets(state, paginationSection, searchString),
       loading: selectDatasetsIsFetching(state, paginationSection, searchString),
-      nextPage: selectDatasetsPageCount(state, paginationSection, searchString) + 1,
+      nextPage: selectDatasetsPageCount(state, paginationSection, searchString),
       fetchedAll: selectDatasetsFetchedAll(state, paginationSection, searchString)
     }, ownProps)
   }, {

--- a/app/reducers/app.js
+++ b/app/reducers/app.js
@@ -1,9 +1,11 @@
-import { APP_TOGGLE_MENU, APP_HIDE_MENU, APP_SHOW_MODAL, APP_HIDE_MODAL, SET_SEARCH, SET_CHART_CONFIG } from '../constants/app'
+import { APP_TOGGLE_MENU, APP_HIDE_MENU, APP_SHOW_MODAL, APP_HIDE_MODAL, SET_SEARCH, SET_CHART_CONFIG,
+SET_MESSAGE } from '../constants/app'
 
 const initialState = {
   showMenu: false,
   modal: undefined,
-  search: {}
+  search: {},
+  message: ''
 }
 
 export default function appReducer (state = initialState, action) {
@@ -16,6 +18,8 @@ export default function appReducer (state = initialState, action) {
       return Object.assign({}, state, { modal: action.modal })
     case APP_HIDE_MODAL:
       return Object.assign({}, state, { modal: undefined })
+    case SET_MESSAGE:
+      return Object.assign({}, state, { message: action.message })
     case SET_SEARCH:
       return Object.assign({}, state, {search: action.search})
     // whenever the route changes, close the menu

--- a/app/reducers/paginate.js
+++ b/app/reducers/paginate.js
@@ -18,7 +18,7 @@ const paginate = ({ types, mapActionToKey }) => {
   const updatePagination = (state = {
     isFetching: false,
     // nextPageUrl: undefined,
-    pageCount: 0,
+    pageCount: 1,
     fetchedAll: false,
     ids: []
   }, action) => {
@@ -31,7 +31,7 @@ const paginate = ({ types, mapActionToKey }) => {
           ids: union(state.ids, action.response.result),
           // nextPageUrl: action.response.nextPageUrl,
           fetchedAll: (action.response.result.length < action.pageSize),
-          pageCount: state.pageCount + 1
+          pageCount: state.pageCount
         })
       case failureType:
         return Object.assign({}, state, {

--- a/app/selectors/dataset.js
+++ b/app/selectors/dataset.js
@@ -12,7 +12,6 @@ export function selectDataset (state, id) {
   if (!datasetRef) {
     datasetRef = Object.assign(state.entities.peerNamespace[id], {peer: true})
   }
-  console.log(datasetRef)
   return datasetRef
 }
 

--- a/app/selectors/dataset.js
+++ b/app/selectors/dataset.js
@@ -9,12 +9,11 @@ export function addressPath (address) {
 
 export function selectDataset (state, id) {
   let datasetRef = state.entities.namespace[id]
-  let peer = false
   if (!datasetRef) {
-    datasetRef = state.entities.peerNamespace[id]
-    peer = true
+    datasetRef = Object.assign(state.entities.peerNamespace[id], {peer: true})
   }
-  return { datasetRef, peer }
+  console.log(datasetRef)
+  return datasetRef
 }
 
 export function selectDatasetByPath (state, path) {

--- a/app/selectors/peers.js
+++ b/app/selectors/peers.js
@@ -1,3 +1,5 @@
+import { selectDataset } from './dataset.js'
+
 const usersPeersSection = 'popularPeers'
 const usersPeersNode = 'popularPeers'
 
@@ -49,7 +51,7 @@ export function selectPeerNamespaceIds (state, path) {
 
 export function selectPeerNamespace (state, path) {
   const { peerNamespace } = state.entities
-  return selectPeerNamespaceIds(state, path).map(id => peerNamespace[id])
+  return selectPeerNamespaceIds(state, path).map(id => selectDataset(state, id))
 }
 
 export function selectPeerById (state, path) {


### PR DESCRIPTION
- All local datasets are now indicated by a checkmark
  - Currently, checkmarks show if the namespace is loaded into entities.namespace, if we have the dataset on the server, but it wasn't fetched by the front end, and it shows up in a peer's namespace, it will not indicate that we have also have a copy of that dataset
  - Should we fix this by loading a reference to all our datasets on app load, or have the backend make a notation if we have a local version?
- addDataset give throws an alert(), not a `message` because `message` isn't formatted nice enough yet
- Until pagination is settled, took out references to loading nextPage in any loadDatasets()