### PR TITLE
Fixing loading spinner/search bug

### DIFF
--- a/lib/components/Datasets.js
+++ b/lib/components/Datasets.js
@@ -24,7 +24,6 @@ export default class Datasets extends Base {
 
     this.debounceRunDatasetSearch = debounce((searchString) => {
       searchString ? this.props.runDatasetSearch(searchString) : undefined
-      this.setState({ loading: false })
     }
     , 250);
 


### PR DESCRIPTION
Took out line that was setting `loading` to `false` prematurely