### PR TITLE
refactor(layout): remove references to layout reducer (except in App container)

### DIFF
--- a/lib/actions/dataset.js
+++ b/lib/actions/dataset.js
@@ -3,7 +3,7 @@ import { push } from 'react-router-redux'
 
 import { CALL_API } from '../middleware/api'
 import Schemas from '../schemas'
-// import { selectDatasetByPath } from '../selectors/dataset'
+import { selectDatasetByPath } from '../selectors/dataset'
 import { newLocalModel, updateLocalModel, removeLocalModel } from './locals'
 import { setMessage, resetMessage, setSearch, clearPagination } from './app'
 
@@ -133,15 +133,15 @@ export function fetchDataset (path) {
 
 export function loadDataset (path, requiredFields = []) {
   return (dispatch, getState) => {
-    // const datasetRef = selectDatasetByPath(getState(), path)
-    // if (!datasetRef) {
-    //   return null
-    // }
-    // if (dataset && requiredFields.every(key => dataset.hasOwnProperty(key))) {
-    //   return null
-    // }
+    const datasetRef = selectDatasetByPath(getState(), path)
+    if (datasetRef && datasetRef.dataset && typeof datasetRef.dataset.structure === 'string') {
+      return dispatch(fetchDataset(path, requiredFields))
+    }
+    if (datasetRef && datasetRef.dataset && requiredFields.every(key => datasetRef.dataset.hasOwnProperty(key))) {
+      return null
+    }
 
-    return dispatch(fetchDataset(path, requiredFields))
+    return dispatch(fetchDataset(path))
   }
 }
 

--- a/lib/actions/dataset.js
+++ b/lib/actions/dataset.js
@@ -134,6 +134,8 @@ export function fetchDataset (path) {
 export function loadDataset (path, requiredFields = []) {
   return (dispatch, getState) => {
     const datasetRef = selectDatasetByPath(getState(), path)
+    // datasets are stored with their structure as a hash reference
+    // ensure dataset structure is dereferenced
     if (datasetRef && datasetRef.dataset && typeof datasetRef.dataset.structure === 'string') {
       return dispatch(fetchDataset(path, requiredFields))
     }

--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -155,7 +155,7 @@ export default class App extends Base {
       <div className={css('app')} onClick={this.handleStageClick}>
         {this.renderMessage(css)}
         {this.renderErrorMessage(css)}
-        <Header palette={palette} style={layout.navbar} />
+        <Header />
         <Menu palette={palette} location={location} user={user} style={layout.sidebar} />
         <div
           className='main'

--- a/lib/components/Console.js
+++ b/lib/components/Console.js
@@ -122,39 +122,37 @@ export default class Console extends Base {
   }
 
   template (css) {
-    const { datasetRef, data, query, topPanelIndex, bottomPanelIndex, topBox, bottomBox, size, chartOptions, loadingData, loadingDataError } = this.props
+    const { datasetRef, data, query, bottomPanelIndex, chartOptions, loadingData, loadingDataError } = this.props
     return (
       <div className={css('wrap')}>
-        <div className={css('top')} style={{height: topBox.height}}>
+        <div className={css('top')} >
           <div className='panel'>
-            <QueryEditor bounds={topBox} name='editor' query={query} onRun={this.handleRunQuery} onDownload={this.handleDownloadQuery} onChange={this.handleEditorChange}
+            <QueryEditor name='editor' query={query} onRun={this.handleRunQuery} onDownload={this.handleDownloadQuery} onChange={this.handleEditorChange}
             />
           </div>
         </div>
-        <div className={css('bottom')} style={{height: bottomBox.height}}>
+        <div className={css('bottom')} >
           <TabPanel
             index={bottomPanelIndex}
             labels={['Data', 'Chart', 'Datasets', 'History']}
             onSelectPanel={this.handleSetBottomPanel}
-            bounds={bottomBox}
             components={[
               <DatasetDataGrid
                 dataset={datasetRef && datasetRef.dataset}
                 data={data}
                 onLoadMore={this.handleLoadMoreResults}
-                bounds={bottomBox}
                 loading={loadingData}
                 error={loadingDataError}
                 onSetLoadingData={this.handleSetLoadingData}
               />,
               <div className='panel'>
-                <ResultsChart size={size} onOptionsChange={this.handleSetChartOptions} schema={datasetRef && datasetRef.dataset.structure.schema} data={data} chartOptions={chartOptions} />
+                <ResultsChart size={{}} onOptionsChange={this.handleSetChartOptions} schema={datasetRef && datasetRef.dataset.structure.schema} data={data} chartOptions={chartOptions} />
               </div>,
               <div className='panel'>
-                <DatasetsContainer skipLoad bounds={bottomBox} padding={false} goBack={this.handleGoBack} noHeader />
+                <DatasetsContainer skipLoad padding={false} goBack={this.handleGoBack} noHeader />
               </div>,
               <div className='panel'>
-                <QueriesContainer skipLoad bounds={topBox} />
+                <QueriesContainer skipLoad />
               </div>
             ]}
           />
@@ -182,7 +180,6 @@ export default class Console extends Base {
 Console.propTypes = {
   // query slug to load to
   slug: PropTypes.string,
-  size: PropTypes.string,
   query: PropTypes.object.isRequired,
   // dataset: PropTypes.array,
   queries: PropTypes.array,
@@ -190,8 +187,6 @@ Console.propTypes = {
   results: PropTypes.object,
   topPanelIndex: PropTypes.number.isRequired,
   bottomPanelIndex: PropTypes.number.isRequired,
-  topBox: PropTypes.object.isRequired,
-  bottomBox: PropTypes.object.isRequired,
   chartOptions: PropTypes.shape({
     type: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,

--- a/lib/components/Console.js
+++ b/lib/components/Console.js
@@ -126,26 +126,15 @@ export default class Console extends Base {
     return (
       <div className={css('wrap')}>
         <div className={css('top')} style={{height: topBox.height}}>
-          <TabPanel
-            index={topPanelIndex}
-            onSelectPanel={this.handleSetTopPanel}
-            labels={['Editor', 'History']}
-            bounds={topBox}
-            components={[
-              <div className='panel'>
-                <QueryEditor bounds={topBox} name='editor' query={query} onRun={this.handleRunQuery} onDownload={this.handleDownloadQuery} onChange={this.handleEditorChange}
-                />
-              </div>,
-              <div className='panel'>
-                <QueriesContainer skipLoad bounds={topBox} />
-              </div>
-            ]}
-          />
+          <div className='panel'>
+            <QueryEditor bounds={topBox} name='editor' query={query} onRun={this.handleRunQuery} onDownload={this.handleDownloadQuery} onChange={this.handleEditorChange}
+            />
+          </div>
         </div>
         <div className={css('bottom')} style={{height: bottomBox.height}}>
           <TabPanel
             index={bottomPanelIndex}
-            labels={['Data', 'Chart', 'Datasets']}
+            labels={['Data', 'Chart', 'Datasets', 'History']}
             onSelectPanel={this.handleSetBottomPanel}
             bounds={bottomBox}
             components={[
@@ -163,6 +152,9 @@ export default class Console extends Base {
               </div>,
               <div className='panel'>
                 <DatasetsContainer skipLoad bounds={bottomBox} padding={false} goBack={this.handleGoBack} noHeader />
+              </div>,
+              <div className='panel'>
+                <QueriesContainer skipLoad bounds={topBox} />
               </div>
             ]}
           />

--- a/lib/components/Console.js
+++ b/lib/components/Console.js
@@ -170,9 +170,6 @@ export default class Console extends Base {
       top: {
         marginTop: 40
       }
-      // bottom: {
-      //   height: this.props.bottomBox.height
-      // }
     }
   }
 }

--- a/lib/components/Dataset.js
+++ b/lib/components/Dataset.js
@@ -205,7 +205,17 @@ export default class Dataset extends Base {
     const { tabIndex } = this.state
     return (
       <div className={css('wrap')} >
-        <DatasetHeader datasetRef={datasetRef} onClickDelete={this.handleDeleteDataset(peer)} exportPath={this.handleDownloadDataset(path, peer)} onClickEdit={this.handleEditMetadata(path, peer)} onGoBack={this.handleGoBack} onClickAdd={this.handleAddDataset(path, name, peer)} onClickRename={this.handleShowRenameModal(peer, datasetRef)} peer={peer} description={this.handleDescription(dataset)} />
+        <DatasetHeader
+          datasetRef={datasetRef}
+          onClickDelete={this.handleDeleteDataset(peer)}
+          exportPath={this.handleDownloadDataset(path, peer)}
+          onClickEdit={this.handleEditMetadata(path, peer)}
+          onGoBack={this.handleGoBack}
+          onClickAdd={this.handleAddDataset(path, name, peer)}
+          onClickRename={this.handleShowRenameModal(peer, datasetRef)}
+          peer={peer}
+          description={this.handleDescription(dataset)}
+        />
         <TabPanel
           index={tabIndex}
           labels={['Data', 'Fields', 'History']}

--- a/lib/components/Dataset.js
+++ b/lib/components/Dataset.js
@@ -42,13 +42,12 @@ export default class Dataset extends Base {
   }
 
   componentWillMount () {
-    if (!this.props.datasetRef) {
-      this.props.loadDataset(this.props.path)
-    } else {
-      this.props.loadDatasetData(this.props.datasetRef.path, (error) => {
+    this.props.loadDataset(this.props.path)
+    this.props.loadDatasetData(this.props.datasetRef.path, (error) => {
+      if (error) {
         this.setState({loading: false, error: error})
-      })
-    }
+      }
+    })
   }
 
   componentWillReceiveProps (nextProps) {
@@ -58,8 +57,14 @@ export default class Dataset extends Base {
       this.changeTabIndex(0)
       this.props.loadDatasetData(nextProps.path,
         (error) => {
-          this.setState({loading: false, error: error})
+          if (error) {
+            this.setState({loading: false, error: error})
+          }
         })
+    } else if (nextProps.datasetRef !== this.props.datasetRef) {
+      this.setState({loading: false})
+    } else if (nextProps.data !== this.props.data) {
+      this.setState({loading: false})
     }
   }
 

--- a/lib/components/Dataset.js
+++ b/lib/components/Dataset.js
@@ -144,9 +144,9 @@ export default class Dataset extends Base {
     }
   }
 
-  renderFieldsList (css, bottomBox, dataset) {
+  renderFieldsList (css, dataset) {
     if (dataset.structure && dataset.structure.schema) {
-      return (<div className={css('overflow')} style={{ height: `${bottomBox.height - 79}px` }}><FieldsList fields={dataset.structure.schema.fields} /></div>)
+      return (<div className={css('overflow')} ><FieldsList fields={dataset.structure.schema.fields} /></div>)
     } else {
       return (<p>This dataset currently has no specified fields</p>)
     }
@@ -161,7 +161,7 @@ export default class Dataset extends Base {
     }
   }
 
-  renderData (bottomBox) {
+  renderData () {
     const { data, datasetRef } = this.props
     const { loading, error } = this.state
     return (
@@ -172,19 +172,18 @@ export default class Dataset extends Base {
         onSetLoadingData={this.handleSetLoadingData}
         loading={loading}
         error={error}
-        bounds={bottomBox}
               />
     )
   }
 
-  renderHistory (bottomBox, path) {
+  renderHistory (path) {
     return (
-      <HistoryContainer bounds={bottomBox} path={path} />
+      <HistoryContainer path={path} />
     )
   }
 
   template (css) {
-    const { datasetRef, topBox, bottomBox } = this.props
+    const { datasetRef } = this.props
     // const path = "/" + address.replace(".", "/", -1)
     // const hasData = (dataset && (dataset.url || dataset.file || dataset.data));
     // TODO hasData is assigned a value but never used, consider depreciation
@@ -201,16 +200,15 @@ export default class Dataset extends Base {
     const { tabIndex } = this.state
     return (
       <div className={css('wrap')} >
-        <DatasetHeader datasetRef={datasetRef} onClickDelete={this.handleDeleteDataset(peer)} exportPath={this.handleDownloadDataset(path, peer)} onClickEdit={this.handleEditMetadata(path, peer)} onGoBack={this.handleGoBack} onClickAdd={this.handleAddDataset(path, name, peer)} onClickRename={this.handleShowRenameModal(peer, datasetRef)} peer={peer} bounds={topBox} description={this.handleDescription(dataset)} />
+        <DatasetHeader datasetRef={datasetRef} onClickDelete={this.handleDeleteDataset(peer)} exportPath={this.handleDownloadDataset(path, peer)} onClickEdit={this.handleEditMetadata(path, peer)} onGoBack={this.handleGoBack} onClickAdd={this.handleAddDataset(path, name, peer)} onClickRename={this.handleShowRenameModal(peer, datasetRef)} peer={peer} description={this.handleDescription(dataset)} />
         <TabPanel
           index={tabIndex}
           labels={['Data', 'Fields', 'History']}
           onSelectPanel={this.changeTabIndex}
-          bounds={bottomBox}
           components={[
-            this.renderData(bottomBox),
-            this.renderFieldsList(css, bottomBox, dataset),
-            this.renderHistory(bottomBox, path)
+            this.renderData(),
+            this.renderFieldsList(css, dataset),
+            this.renderHistory(path)
           ]}
         />
       </div>
@@ -246,9 +244,6 @@ Dataset.propTypes = {
   path: PropTypes.string,
   goBack: PropTypes.func.isRequired,
   runQuery: PropTypes.func.isRequired,
-  bounds: PropTypes.object.isRequired,
-  topBox: PropTypes.object.isRequired,
-  bottomBox: PropTypes.object.isRequired,
   palette: Palette
 }
 

--- a/lib/components/DatasetDataGrid.js
+++ b/lib/components/DatasetDataGrid.js
@@ -105,7 +105,7 @@ class DatasetDataGrid extends React.Component {
         onGridSort={this.handleGridSort}
         columns={this.schemaColumns(dataset, data)}
         rowGetter={this.rowGetter}
-        rowsCount={data.length}
+        rowsCount={data ? data.length : 0}
         rowHeight={50}
         headerRowHeight={50}
         minHeight={1000}

--- a/lib/components/DatasetDataGrid.js
+++ b/lib/components/DatasetDataGrid.js
@@ -85,9 +85,7 @@ class DatasetDataGrid extends React.Component {
         <Spinner />
       )
     }
-    const { dataset, data, bounds } = this.props
-    const height = bounds.height - 79
-    const width = bounds.width - 50
+    const { dataset, data } = this.props
     if (this.props.error) {
       return (
         <div className='panel'>
@@ -110,8 +108,7 @@ class DatasetDataGrid extends React.Component {
         rowsCount={data.length}
         rowHeight={50}
         headerRowHeight={50}
-        minHeight={height}
-        winWidth={width}
+        minHeight={1000}
         />
     )
   }

--- a/lib/components/DatasetHeader.js
+++ b/lib/components/DatasetHeader.js
@@ -31,10 +31,10 @@ export default class DatasetHeader extends Base {
   }
 
   template (css) {
-    const { datasetRef, exportPath, onClickEdit, onClickRename, onClickDelete, onClickAdd, onGoBack, peer, bounds, description } = this.props
+    const { datasetRef, exportPath, onClickEdit, onClickRename, onClickDelete, onClickAdd, onGoBack, peer, description } = this.props
     const { name } = datasetRef
     return (
-      <div className='dataSetHeader' style={{height: bounds.height}}>
+      <div className='dataSetHeader'>
         <PageHeader
           onGoBack={onGoBack}
           exportPath={exportPath}
@@ -44,7 +44,7 @@ export default class DatasetHeader extends Base {
           onClickAdd={onClickAdd}
           name={name}
         />
-        <div className={css('item')} style={{height: bounds.height - 41}}>
+        <div className={css('item')} >
           <DatasetItem data={datasetRef} link={false} peer={peer} />
           {this.renderDescription(css, description)}
         </div>

--- a/lib/components/DatasetHeader.js
+++ b/lib/components/DatasetHeader.js
@@ -12,21 +12,25 @@ export default class DatasetHeader extends Base {
   constructor (props) {
     super(props)
     this.state = {
-      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
-      shortDescription: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua',
-      arrow: 'ss-directright',
-      linkText: '...(read more)'
+      readMore: true
     };
     [
-      'renderDescription'
+      'renderDescription',
+      'handleReadMore'
     ].forEach((m) => { this[m] = this[m].bind(this) })
+  }
+
+  handleReadMore (e) {
+    this.setState({readMore: !this.state.readMore})
   }
 
   renderDescription (css, description) {
     if (description.length < 120) {
       return (<p>{description}</p>)
+    } else if (this.state.readMore) {
+      return (<p>{description.slice(0, 120)}<span className={`${css('linkText')} ${css('link')}`} onClick={this.handleReadMore}>... <small>(read more)</small></span></p>)
     } else {
-      return (<p>{description.slice(0, 120)}<span className={`${css('linkText')} ${css('link')}`}>{this.state.linkText}</span></p>)
+      return (<p>{description}<span className={`${css('linkText')} ${css('link')}`} onClick={this.handleReadMore}> <small>(read less)</small></span></p>)
     }
   }
 

--- a/lib/components/Datasets.js
+++ b/lib/components/Datasets.js
@@ -154,8 +154,7 @@ export default class Datasets extends Base {
   }
 
   styles (props) {
-    const { padding, bounds } = this.props
-    const height = bounds.height - 145
+    const { padding } = this.props
     let paddingRight = 0
     if (padding) {
       paddingRight = 20
@@ -166,8 +165,7 @@ export default class Datasets extends Base {
       },
       wrap: {
         paddingLeft: paddingRight,
-        paddingRight: paddingRight,
-        height: `${bounds.height - 59}px`
+        paddingRight: paddingRight
       },
       searchBox: {
         display: 'inline-block',
@@ -177,8 +175,7 @@ export default class Datasets extends Base {
       },
       list: {
         position: 'relative',
-        overflow: 'auto',
-        height: `${height}px`
+        overflow: 'auto'
       },
       hr: {
         marginTop: 0

--- a/lib/components/Datasets.js
+++ b/lib/components/Datasets.js
@@ -100,7 +100,7 @@ export default class Datasets extends Base {
       return (
         <div className={css('wrap')}>
           <header>
-            { noHeader === true ? undefined : <div><h1>Datasets</h1><hr /></div>}
+            { noHeader === true ? undefined : <div className={css('marginTop')}><h1>Datasets</h1><hr /></div>}
             <input
               id={'search'}
               name={'search'}
@@ -121,7 +121,7 @@ export default class Datasets extends Base {
     return (
       <div className={css('wrap')}>
         <header>
-          { noHeader ? undefined : <div><h1>Datasets</h1><hr className={css('marginTop')} /></div>}
+          { noHeader ? undefined : <div className={css('marginTop')}><h1>Datasets</h1><hr className={css('hr')} /></div>}
           <input
             id='search'
             name='search'
@@ -161,8 +161,10 @@ export default class Datasets extends Base {
       paddingRight = 20
     }
     return {
+      marginTop: {
+        marginTop: 40
+      },
       wrap: {
-        marginTop: 40,
         paddingLeft: paddingRight,
         paddingRight: paddingRight,
         height: `${bounds.height - 59}px`
@@ -178,7 +180,7 @@ export default class Datasets extends Base {
         overflow: 'auto',
         height: `${height}px`
       },
-      marginTop: {
+      hr: {
         marginTop: 0
       }
     }

--- a/lib/components/PageHeader.js
+++ b/lib/components/PageHeader.js
@@ -6,9 +6,9 @@ import Base from './Base'
 
 export default class PageHeader extends Base {
   template (css) {
-    const { onGoBack, name } = this.props
+    const { onGoBack, name, profile } = this.props
     return (
-      <div className={css('wrap')}>
+      <div className={`${css('wrap')} ${profile ? css('paddingLeftRight') : undefined}`}>
         <div>
           <a className={`left ${css('link')}`} onClick={onGoBack}>◂ Back</a>
           {this.props.onClickAdd ? <a onClick={this.props.onClickAdd} className={`right ${css('link')}`}>Add </a> : undefined}
@@ -30,7 +30,12 @@ export default class PageHeader extends Base {
     const { palette } = props
     return {
       wrap: {
-        padding: `40px 20px 10px 20px`
+        paddingTop: 40,
+        paddingBottom: 10
+      },
+      paddingLeftRight: {
+        paddingLeft: 20,
+        paddingRight: 20
       },
       hr: {
         borderTop: `1px solid ${palette.a}`,
@@ -48,6 +53,7 @@ export default class PageHeader extends Base {
 
 PageHeader.propTypes = {
   name: PropTypes.string,
+  profile: PropTypes.Bool,
   onGoBack: PropTypes.func.isRequired,
   onClickAdd: PropTypes.func,
   exportPath: PropTypes.string,
@@ -59,5 +65,6 @@ PageHeader.propTypes = {
 }
 
 PageHeader.defaultProps = {
-  palette: defaultPalette
+  palette: defaultPalette,
+  profile: false
 }

--- a/lib/components/PageHeader.js
+++ b/lib/components/PageHeader.js
@@ -7,8 +7,9 @@ import Base from './Base'
 export default class PageHeader extends Base {
   template (css) {
     const { onGoBack, name, profile } = this.props
+    const padding = profile ? 'paddingLeftRight' : undefined
     return (
-      <div className={`${css('wrap')} ${profile ? css('paddingLeftRight') : undefined}`}>
+      <div className={css('wrap', padding)}>
         <div>
           <a className={`left ${css('link')}`} onClick={onGoBack}>◂ Back</a>
           {this.props.onClickAdd ? <a onClick={this.props.onClickAdd} className={`right ${css('link')}`}>Add </a> : undefined}

--- a/lib/components/PageHeader.js
+++ b/lib/components/PageHeader.js
@@ -53,7 +53,7 @@ export default class PageHeader extends Base {
 
 PageHeader.propTypes = {
   name: PropTypes.string,
-  profile: PropTypes.Bool,
+  profile: PropTypes.bool,
   onGoBack: PropTypes.func.isRequired,
   onClickAdd: PropTypes.func,
   exportPath: PropTypes.string,

--- a/lib/components/Peer.js
+++ b/lib/components/Peer.js
@@ -114,7 +114,7 @@ export default class Peer extends Base {
   }
 
   template (css) {
-    const { peer, topBox, bottomBox, setPosterPhoto, setProfilePhoto } = this.props
+    const { peer, setPosterPhoto, setProfilePhoto } = this.props
     const { tabIndex } = this.state
     return (
       <div className={css('wrap')}>
@@ -122,7 +122,6 @@ export default class Peer extends Base {
           onGoBack={this.handleGoBack}
           setPosterPhoto={setPosterPhoto}
           setProfilePhoto={setProfilePhoto}
-          bounds={topBox}
           peer={peer}
         />
         <div className={css('main')}>
@@ -134,7 +133,6 @@ export default class Peer extends Base {
               index={tabIndex}
               labels={['Datasets']}
               onSelectPanel={this.changeTabIndex}
-              bounds={bottomBox}
               components={[
                 this.renderPeerDatasets(css)
               ]}

--- a/lib/components/PeerHeader.js
+++ b/lib/components/PeerHeader.js
@@ -158,7 +158,6 @@ export default class PeerHeader extends Base {
 PeerHeader.propTypes = {
   onGoBack: PropTypes.func.isRequired,
   peer: PropTypes.object.isRequired,
-  bounds: PropTypes.object.isRequired,
   setPosterPhoto: PropTypes.func,
   setProfilePhoto: PropTypes.func,
 

--- a/lib/components/PeerHeader.js
+++ b/lib/components/PeerHeader.js
@@ -66,6 +66,7 @@ export default class PeerHeader extends Base {
       <div className={css('wrap')}>
         <PageHeader
           onGoBack={onGoBack}
+          profile
         />
         {setPosterPhoto && this.renderChoosePosterPhoto(css)}
         <div className={css('info')}>

--- a/lib/components/Queries.js
+++ b/lib/components/Queries.js
@@ -72,9 +72,8 @@ export default class Queries extends Base {
 
   template (css) {
     const { loading } = this.state
-    const { queries, palette, bounds, fetchedAll } = this.props
-    let height = bounds.height - 57
-    bounds.height = height
+    const { queries, palette, fetchedAll } = this.props
+
     if (loading) {
       return (
         <div className={css('wrap')}>
@@ -90,7 +89,6 @@ export default class Queries extends Base {
           onSelectItem={this.handleMultiFunc}
           emptyComponent={<label>No Queries</label>}
           palette={palette}
-          style={bounds}
           loading={this.props.loading}
           fetchedAll={fetchedAll}
           onClick={this.handleLoadNextPage}

--- a/lib/components/QueryEditor.js
+++ b/lib/components/QueryEditor.js
@@ -14,8 +14,8 @@ export default class QueryEditor extends Base {
           name={name}
           value={query.queryString}
           completers={[datasetCompleter]}
-          width={'100%'}
-          height={'200px'}
+          width='100%'
+          height='200px'
           onChange={value => onChange({ queryString: value, address: query.address })}
         // TODO - reenable when adding back completion
         // setOptions={{

--- a/lib/components/QueryEditor.js
+++ b/lib/components/QueryEditor.js
@@ -7,15 +7,15 @@ import { datasetCompleter } from '../ace/completer/datasets'
 
 export default class QueryEditor extends Base {
   template (css) {
-    const { name, query, onRun, onChange, bounds } = this.props
+    const { name, query, onRun, onChange } = this.props
     return (
       <div className={css('wrap')}>
         <CodeEditor
           name={name}
           value={query.queryString}
           completers={[datasetCompleter]}
-          width={`${bounds.width - 40}px`}
-          height={`${bounds.height - 97}px`}
+          width={'100%'}
+          height={'200px'}
           onChange={value => onChange({ queryString: value, address: query.address })}
         // TODO - reenable when adding back completion
         // setOptions={{
@@ -56,8 +56,7 @@ QueryEditor.propTypes = {
   query: PropTypes.object,
   // datasets: PropTypes.array,
   onRun: PropTypes.func.isRequired,
-  onChange: PropTypes.func.isRequired,
-  bounds: PropTypes.object
+  onChange: PropTypes.func.isRequired
 }
 
 QueryEditor.defaultProps = {

--- a/lib/components/ResultsChart.js
+++ b/lib/components/ResultsChart.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import BarChart from './BarChart.js'
-import LineChart from './LineChart.js'
+import Base from './Base'
+import BarChart from './BarChart'
+import LineChart from './LineChart'
 import ChartOptionsPicker from './ChartOptionsPicker'
 import { schemaProps } from '../propTypes/datasetRefProps'
 
@@ -47,7 +48,7 @@ function chartDimensions (size) {
   return { width, height }
 }
 
-class ResultsChart extends React.Component {
+export default class ResultsChart extends Base {
   constructor (props) {
     super(props);
 
@@ -57,9 +58,9 @@ class ResultsChart extends React.Component {
   }
 
   renderChart () {
-    const { data, chartOptions, size } = this.props
+    const { data, chartOptions } = this.props
     const { title, xTitle, type } = chartOptions
-    const { width, height } = chartDimensions(size)
+    const { width, height } = chartDimensions('md')
 
     switch (type) {
       case 'line':
@@ -86,7 +87,7 @@ class ResultsChart extends React.Component {
     }
   }
 
-  render () {
+  template (css) {
     const { schema, data, chartOptions, onOptionsChange } = this.props
     const { xIndex, yIndex, type } = chartOptions
     if (!data) {
@@ -99,9 +100,17 @@ class ResultsChart extends React.Component {
     return (
       <div className='resultsChart'>
         <ChartOptionsPicker schema={schema} options={chartOptions} onChange={onOptionsChange} />
-        { (xIndex !== undefined && yIndex !== undefined && type) ? this.renderChart() : undefined }
+        { (xIndex !== undefined && yIndex !== undefined && type) ? <div className={css('chartWrapper')} >{this.renderChart()}</div> : undefined }
       </div>
     )
+  }
+
+  styles () {
+    return {
+      chartWrapper: {
+        marginTop: 20
+      }
+    }
   }
 }
 
@@ -116,11 +125,8 @@ ResultsChart.propTypes = {
     yIndex: PropTypes.number,
     path: PropTypes.string.isRequired
   }).isRequired,
-  size: PropTypes.string.isRequired,
   onOptionsChange: PropTypes.func.isRequired
 }
 
 ResultsChart.defaultProps = {
 }
-
-export default ResultsChart

--- a/lib/components/Settings.js
+++ b/lib/components/Settings.js
@@ -80,10 +80,9 @@ export default class Settings extends Base {
   }
 
   template (css) {
-    const { index, bounds, profile } = this.props
-    const tabPanelBounds = Object.assign({}, bounds, { height: bounds.height - 69 })
+    const { index, profile } = this.props
     return (
-      <div className={css('wrap')} style={{height: `${bounds.height}px`}}>
+      <div className={css('wrap')} >
         <header>
           <h1>Settings</h1>
           { profile && profile.id ? <p><b className={css('name')}>my hash:</b> {profile.id}</p> : undefined}
@@ -93,7 +92,6 @@ export default class Settings extends Base {
           index={index}
           labels={['Profile', 'Theme']}
           onSelectPanel={this.handleSetPanel}
-          bounds={tabPanelBounds}
           components={[
             this.renderProfile(),
             this.renderTheme()
@@ -104,13 +102,12 @@ export default class Settings extends Base {
   }
 
   styles () {
-    const {bounds, palette} = this.props
+    const {palette} = this.props
     return {
       wrap: {
         marginTop: 40,
         paddingLeft: 20,
-        paddingRight: 20,
-        height: `${bounds.height}px`
+        paddingRight: 20
       },
       name: {
         color: palette.b,
@@ -123,7 +120,6 @@ export default class Settings extends Base {
 
 Settings.PropTypes = {
   settings: PropTypes.object,
-  bounds: PropTypes.object,
   palette: Palette
 }
 

--- a/lib/components/TabPanel.js
+++ b/lib/components/TabPanel.js
@@ -12,10 +12,10 @@ function panelTrigger (i, fn) {
 
 export default class TabPanel extends Base {
   template (css) {
-    const { index, labels = [], components, onSelectPanel, bounds } = this.props
+    const { index, labels = [], components, onSelectPanel } = this.props
     const component = components[index]
     return (
-      <div className={css('wrapper')} style={{height: `${bounds.height}px`}}>
+      <div className={css('wrapper')} >
         <div className={`${css('header')}`}>
           {labels.map((label, i) => {
             return (
@@ -28,7 +28,7 @@ export default class TabPanel extends Base {
           )}
         </div>
         <hr className={css('black')} />
-        <div className={css('componentWrapper')} style={{height: `${bounds.height - 59}px`}}>
+        <div>
           {component}
         </div>
       </div>
@@ -59,9 +59,6 @@ export default class TabPanel extends Base {
       black: {
         'border-top': `1px solid ${palette.overlay}`,
         'margin-top': 0
-      },
-      componentWrapper: {
-        overflow: 'auto'
       }
     }
   }
@@ -72,7 +69,6 @@ TabPanel.propTypes = {
   labels: PropTypes.array.isRequired,
   components: PropTypes.array.isRequired,
   onSelectPanel: PropTypes.func.isRequired,
-  bounds: PropTypes.object.isRequired,
   palette: Palette
 }
 

--- a/lib/containers/Console.js
+++ b/lib/containers/Console.js
@@ -12,36 +12,17 @@ const ConsoleContainer = connect(
     if (datasetRef) {
       data = state.entities.data[datasetRef.path] && state.entities.data[datasetRef.path].data
     }
-    const main = state.layout.main
-    const topBox = {
-      top: main.top,
-      left: 0,
-      width: main.width,
-      height: main.height * 0.4,
-      overflow: 'auto'
-    }
-    const bottomBox = {
-      top: main.height * 0.4,
-      left: 0,
-      width: main.width,
-      height: main.height * 0.6,
-      overflow: 'auto'
-    }
-    const size = state.layout.size ? state.layout.size : ''
     return Object.assign({}, {
       loadingData: state.console.loadingData,
       loadingDataError: state.console.loadingDataError,
       queries: Object.keys(state.entities.queries).map(key => state.entities.queries[key]),
       datasets: Object.keys(state.entities.namespace).map(key => state.entities.namespace[key]),
       queryHistory: state.session.history,
-      topBox,
-      bottomBox,
       chartOptions: state.console.chartOptions,
       history: ownProps.history,
       goBack: ownProps.history.goBack,
       datasetRef,
-      data,
-      size
+      data
     }, state.console, ownProps)
   }, {
     setQuery,

--- a/lib/containers/Dataset.js
+++ b/lib/containers/Dataset.js
@@ -13,30 +13,12 @@ const DatasetContainer = connect(
     // console.log(ownProps.match.params)
     // const path = ownProps.path || `/${ownProps.params.splat}`
     const path = `/ipfs/${ownProps.match.params.id}/dataset.json`
-    const bounds = state.layout.main
-    const topBox = {
-      top: bounds.top,
-      left: 0,
-      width: bounds.width,
-      height: bounds.height * 0.3,
-      overflow: 'auto'
-    }
-    const bottomBox = {
-      top: bounds.height * 0.3,
-      left: 0,
-      width: bounds.width,
-      height: bounds.height * 0.7,
-      overflow: 'auto'
-    }
     return Object.assign({
       path,
       datasetRef: selectDataset(state, path),
       data: selectDatasetData(state, path),
       history: ownProps.history,
-      goBack: ownProps.history.goBack,
-      bounds: bounds,
-      topBox,
-      bottomBox
+      goBack: ownProps.history.goBack
     }, state.console, ownProps)
   }, {
     hideModal,

--- a/lib/containers/Datasets.js
+++ b/lib/containers/Datasets.js
@@ -18,8 +18,7 @@ const DatasetsContainer = connect(
       noDatasets: selectNoDatasets(state, paginationSection, paginationNode),
       loading: selectIsFetching(state, paginationSection, paginationNode),
       nextPage: selectPageCount(state, paginationSection, paginationNode) + 1,
-      fetchedAll: selectFetchedAll(state, paginationSection, paginationNode),
-      bounds: state.layout.main
+      fetchedAll: selectFetchedAll(state, paginationSection, paginationNode)
     }, ownProps)
   }, {
     addDataset,

--- a/lib/containers/Peer.js
+++ b/lib/containers/Peer.js
@@ -9,21 +9,6 @@ import { addDataset, loadDatasets } from '../actions/dataset'
 const PeerContainer = connect(
   (state, ownProps) => {
     const path = ownProps.match.params.id
-    const bounds = state.layout.main
-    const topBox = {
-      top: bounds.top,
-      left: 0,
-      width: bounds.width,
-      height: bounds.height * 0.35,
-      overflow: 'auto'
-    }
-    const bottomBox = {
-      top: bounds.height * 0.35,
-      left: 0,
-      width: bounds.width,
-      height: bounds.height * 0.65,
-      overflow: 'auto'
-    }
     return Object.assign({
       path,
       goBack: ownProps.history.goBack,
@@ -33,9 +18,7 @@ const PeerContainer = connect(
       loading: selectPeerNamespaceIsFetching(state, path),
       nextPage: selectPeerNamespacePageCount(state, path) + 1,
       fetchedAll: selectPeerNamespaceFetchedAll(state, path),
-      connected: selectConnected(state, path),
-      topBox,
-      bottomBox
+      connected: selectConnected(state, path)
     }, ownProps)
   }, {
     loadDatasets,

--- a/lib/containers/Peers.js
+++ b/lib/containers/Peers.js
@@ -12,13 +12,11 @@ const PeersContainer = connect(
     // const searchString = selectPeerSearchString(state)
     const paginationSection = 'popularPeers'
     const searchString = 'popularPeers'
-    const bounds = state.layout.main
     return Object.assign({
       peers: selectPeers(state, paginationSection, searchString),
       loading: selectIsFetching(state, paginationSection, searchString),
       nextPage: selectPageCount(state, paginationSection, searchString) + 1,
-      fetchedAll: selectFetchedAll(state, paginationSection, searchString),
-      bounds
+      fetchedAll: selectFetchedAll(state, paginationSection, searchString)
     }, ownProps)
   }, {
     connections,

--- a/lib/containers/Profile.js
+++ b/lib/containers/Profile.js
@@ -13,23 +13,6 @@ import { selectDatasets } from '../selectors/dataset'
 const ProfileContainer = connect(
   (state, ownProps) => {
     const user = selectSessionUser(state)
-    const bounds = state.layout.main
-
-    const topBox = {
-      top: bounds.top,
-      left: 0,
-      width: bounds.width,
-      height: bounds.height * 0.35,
-      overflow: 'auto'
-    }
-    const bottomBox = {
-      top: bounds.height * 0.35,
-      left: 0,
-      width: bounds.width,
-      height: bounds.height * 0.65,
-      overflow: 'auto'
-    }
-
     return Object.assign({
       // TODO - this value must always be present, but on initial load we don't have a user object?
       path: user.id || 'fool!',
@@ -40,9 +23,7 @@ const ProfileContainer = connect(
       loading: selectPeerNamespaceIsFetching(state, user.id),
       nextPage: selectPeerNamespacePageCount(state, user.id) + 1,
       fetchedAll: selectPeerNamespaceFetchedAll(state, user.id),
-      connected: selectConnected(state, user.id),
-      topBox,
-      bottomBox
+      connected: selectConnected(state, user.id)
     }, ownProps)
   }, {
     addDataset,

--- a/lib/containers/Settings.js
+++ b/lib/containers/Settings.js
@@ -11,8 +11,7 @@ const SettingsContainer = connect(
       profile: selectProfile(state),
       index: selectPanelIndex(state),
       theme: selectTheme(state),
-      localProfile: selectLocalProfile(state),
-      bounds: state.layout.main
+      localProfile: selectLocalProfile(state)
     }, ownProps)
   }, {
     loadSettings,

--- a/lib/propTypes/datasetRefProps.js
+++ b/lib/propTypes/datasetRefProps.js
@@ -21,11 +21,14 @@ export const schemaProps = PropTypes.shape({
   fields: fieldsProps
 })
 
-export const structureProps = PropTypes.shape({
-  format: formatProps,
-  formatConfig: formatConfigProps,
-  schema: schemaProps
-})
+export const structureProps = PropTypes.oneOfType([
+  PropTypes.shape({
+    format: formatProps,
+    formatConfig: formatConfigProps,
+    schema: schemaProps
+  }),
+  PropTypes.string
+])
 
 export const datasetProps = PropTypes.shape({
   data: PropTypes.string.isRequired,

--- a/lib/reducers/layout.js
+++ b/lib/reducers/layout.js
@@ -1,14 +1,11 @@
-import { LAYOUT_RESIZE, LAYOUT_SHOW_SIDEBAR, LAYOUT_HIDE_SIDEBAR } from '../constants/layout'
+import { LAYOUT_RESIZE } from '../constants/layout'
 import { defaultPalette } from '../propTypes/palette'
-
-const COLLAPSED_WIDTH = 0
 
 const initialState = {
   size: 'xs',
   stage: { width: 100, height: 100 },
-  navbar: { width: 100, height: 40, left: 0, bottom: 0, collapsed: false },
   main: { width: 100, height: 100, left: 0, top: 0 },
-  sidebar: { width: 80, height: 100, left: 0, top: 0, collapsed: false },
+  sidebar: { width: 80, height: 100, left: 0, top: 0 },
   theme: defaultPalette
 }
 
@@ -16,43 +13,28 @@ export default function layoutReducer (state = initialState, action) {
   switch (action.type) {
     case LAYOUT_RESIZE:
       return layout(Object.assign({}, state, action))
-    case LAYOUT_SHOW_SIDEBAR:
-      return layout(Object.assign({}, state, { sidebar: Object.assign({}, state.sidebar, { collapsed: false }) }))
-    case LAYOUT_HIDE_SIDEBAR:
-      return layout(Object.assign({}, state, { sidebar: Object.assign({}, state.sidebar, { collapsed: true }) }))
   }
 
   return state
 }
 
 function layout (state) {
-  const { stage, navbar, sidebar } = state
+  const { stage, sidebar } = state
 
   return {
     size: sizeClass(state.stage.width),
     stage,
-    navbar: {
-      width: stage.width,
-      height: navbar.height,
-      left: 0,
-      top: 0,
-      collapsed: navbar.collapsed
-    },
     main: {
-      width: sidebar.collapsed ? stage.width - COLLAPSED_WIDTH : stage.width - sidebar.width,
-      height: stage.height - navbar.height,
-      // top: navbar.height,
+      width: stage.width - sidebar.width,
+      height: stage.height,
       top: 0,
-      left: sidebar.collapsed ? stage.width - COLLAPSED_WIDTH : sidebar.width
+      left: sidebar.width
     },
     sidebar: {
-      // width: sidebar.collapsed ? COLLAPSED_WIDTH : stage.width * sidebar.pct_width,
       height: stage.height,
       width: sidebar.width,
       left: 0,
-      top: 0,
-      collapsed: sidebar.collapsed
-      // pct_width: sidebar.pct_width
+      top: 0
     }
   }
 }

--- a/lib/utils/defaultColumnWidths.js
+++ b/lib/utils/defaultColumnWidths.js
@@ -101,11 +101,13 @@ const reducer = (acc, row, i, data) => {
 
 const headersColWidth = dataset => {
   let headers = {}
-  dataset.structure.schema.fields.forEach(val => {
-    const key = val.name
-    const width = cellWidth(key)
-    headers[key] = width
-  })
+  if (dataset && dataset.structure && dataset.structure.schema && dataset.structure.schema.fields) {
+    dataset.structure.schema.fields.forEach(val => {
+      const key = val.name
+      const width = cellWidth(key)
+      headers[key] = width
+    })
+  }
   return headers
 }
 
@@ -128,7 +130,7 @@ const initialObj = dataset => {
 
 const defaultColumnWidths = (dataset, data) => {
   const headers = initialObj(dataset)
-  if (data.length === 0) {
+  if (data === undefined || data.length === 0) {
     return headersColWidth(dataset)
   }
   return data.reduce(reducer, headers)


### PR DESCRIPTION
closes #173 
- [x] Move history to bottom panel
- [x] remove tab panel from top of page, just have query editor

closes #172 
Kill the layout reducer and fix bugs that are left
remove references to bounds/size in 17 files:
- [x] components/Console
- [x] components/ResultsChart
- [x] components/Dataset
- [x] components/DatasetDataGrid
- [x] components/DatasetHeader
- [x] components/Datasets
- [x] components/Peer
- [x] components/PeerHeader
- [x] components/Queries
- [x] components/QueryEditor
- [x] components/Settings
- [x] components/TabPanel
- [x] containers/Datasets
- [x] containers/Peer
- [x] containers/Peers
- [x] containers/Profile
- [x] containers/Settings

For things that need bounds to make sense, choose heights for them maybe have to bound them in relative divs

Layout reducer still contains bounds for Menus and Main in the App Component (removed navbar and references to collapse)

closes #160 
Read more and read less for dataset description
- [x] add readMore flag in state
- [x] add handleReadMore that toggles readMore flag
- [x] use readMore flag to determine what description we show in renderDescription()

closes #157 
search endpoint returns datasetRef with hash as the structure
- [x] in dataset componentWillMount-> always load dataset and data
- [x] in actions/dataset -> loadDataset: check if structure is object, if it is don't reload, else reload