### PR TITLE
Restyling dataset page and inputs

### DIFF
--- a/lib/components/Dataset.js
+++ b/lib/components/Dataset.js
@@ -36,8 +36,14 @@ export default class Dataset extends Base {
       'handleEditMetadata',
       'handleRenameDataset',
       'handleShowRenameModal',
+<<<<<<< HEAD
       'renderStructure',
       'renderData'
+=======
+      'renderFieldsList',
+      'renderData',
+      'renderComingSoon'
+>>>>>>> feat(dataset): styling to make dataset page more closely to the sketch file
     ].forEach((m) => { this[m] = this[m].bind(this) })
   }
 
@@ -187,6 +193,12 @@ export default class Dataset extends Base {
     )
   }
 
+  renderComingSoon (css) {
+    <div className={css('tabPanelWrap')}>
+      <p>Coming soon!</p>
+    </div>
+  }
+
   template (css) {
     const { datasetRef } = this.props
     // const path = "/" + address.replace(".", "/", -1)
@@ -218,14 +230,25 @@ export default class Dataset extends Base {
         />
         <TabPanel
           index={tabIndex}
-          labels={['Data', 'Fields', 'Commits']}
+          labels={['Data', 'Structure', 'Queries', 'Commits', 'Editor']}
           onSelectPanel={this.changeTabIndex}
           components={[
             this.renderData(),
-            this.renderStructure(css, dataset),
-            this.renderCommits(path)
+            this.renderFieldsList(css, dataset),
+            this.renderComingSoon(css),
+            this.renderCommits(path),
+            this.renderComingSoon(css)
           ]}
         />
+        <div className={css('bottomPanel')}>
+          <div className='col-md-7' >
+            <h5>Details</h5>
+            <p>{this.handleDescription(dataset)}</p>
+          </div>
+          <div className='col-md-3'>
+            <h5>Contributors</h5>
+          </div>
+        </div>
       </div>
     )
   }
@@ -239,6 +262,13 @@ export default class Dataset extends Base {
       },
       overflow: {
         overflow: 'auto'
+      },
+      bottomPanel: {
+        marginTop: 40,
+        minHeight: 100
+      },
+      tabPanelWrap: {
+        margin: 20
       }
     }
   }

--- a/lib/components/Dataset.js
+++ b/lib/components/Dataset.js
@@ -37,7 +37,6 @@ export default class Dataset extends Base {
       'handleRenameDataset',
       'handleShowRenameModal',
       'renderStructure',
-      'renderFieldsList',
       'renderData',
       'renderComingSoon'
     ].forEach((m) => { this[m] = this[m].bind(this) })
@@ -190,9 +189,11 @@ export default class Dataset extends Base {
   }
 
   renderComingSoon (css) {
-    <div className={css('tabPanelWrap')}>
-      <p>Coming soon!</p>
-    </div>
+    return (
+      <div className={css('tabPanelWrap')}>
+        <p>Coming soon!</p>
+      </div>
+    )
   }
 
   template (css) {

--- a/lib/components/Dataset.js
+++ b/lib/components/Dataset.js
@@ -36,14 +36,10 @@ export default class Dataset extends Base {
       'handleEditMetadata',
       'handleRenameDataset',
       'handleShowRenameModal',
-<<<<<<< HEAD
       'renderStructure',
-      'renderData'
-=======
       'renderFieldsList',
       'renderData',
       'renderComingSoon'
->>>>>>> feat(dataset): styling to make dataset page more closely to the sketch file
     ].forEach((m) => { this[m] = this[m].bind(this) })
   }
 
@@ -234,7 +230,7 @@ export default class Dataset extends Base {
           onSelectPanel={this.changeTabIndex}
           components={[
             this.renderData(),
-            this.renderFieldsList(css, dataset),
+            this.renderStructure(css, dataset),
             this.renderComingSoon(css),
             this.renderCommits(path),
             this.renderComingSoon(css)

--- a/lib/components/DatasetDataGrid.js
+++ b/lib/components/DatasetDataGrid.js
@@ -108,7 +108,7 @@ class DatasetDataGrid extends React.Component {
         rowsCount={data ? data.length : 0}
         rowHeight={50}
         headerRowHeight={50}
-        minHeight={1000}
+        minHeight={500}
         />
     )
   }

--- a/lib/components/DatasetHeader.js
+++ b/lib/components/DatasetHeader.js
@@ -35,7 +35,7 @@ export default class DatasetHeader extends Base {
   }
 
   template (css) {
-    const { datasetRef, exportPath, onClickEdit, onClickRename, onClickDelete, onClickAdd, onGoBack, peer, description } = this.props
+    const { datasetRef, exportPath, onClickEdit, onClickRename, onClickDelete, onClickAdd, onGoBack, peer } = this.props
     const { name } = datasetRef
     return (
       <div className='dataSetHeader'>

--- a/lib/components/DatasetHeader.js
+++ b/lib/components/DatasetHeader.js
@@ -50,7 +50,7 @@ export default class DatasetHeader extends Base {
         />
         <div className={css('item')} >
           <DatasetItem data={datasetRef} link={false} peer={peer} />
-          {this.renderDescription(css, description)}
+          {/* this.renderDescription(css, description) */}
         </div>
       </div>
     )

--- a/lib/components/DatasetName.js
+++ b/lib/components/DatasetName.js
@@ -7,10 +7,10 @@ import Base from './Base'
 
 export default class DatasetName extends Base {
   template (css) {
-    const { name, large } = this.props
+    const { name, large, style } = this.props
     const datasetLarge = large ? 'large' : undefined
     return (
-      <div className={`datasetName ${datasetLarge} ${css('datasetName')}`}>{name}</div>
+      <div className={`datasetName ${datasetLarge} ${css('datasetName')}`} style={style}>{name}</div>
     )
   }
 
@@ -25,12 +25,14 @@ export default class DatasetName extends Base {
 }
 
 DatasetName.propTypes = {
+  style: PropTypes.object,
   name: PropTypes.string.isRequired,
   large: PropTypes.bool.isRequired,
   palette: Palette
 }
 
 DatasetName.defaultProps = {
+  style: {},
   large: false,
   palette: defaultPalette
 }

--- a/lib/components/Datasets.js
+++ b/lib/components/Datasets.js
@@ -12,6 +12,7 @@ import AddDatasetContainer from '../containers/AddDataset'
 import List from './List'
 import DatasetItem from './item/DatasetItem'
 import Spinner from './Spinner'
+import Search from './Search'
 
 const ADD_DATASET_MODAL = 'ADD_DATASET_MODAL'
 
@@ -103,15 +104,7 @@ export default class Datasets extends Base {
         <div className={css('wrap')}>
           <header>
             { noHeader === true ? undefined : <div className={css('marginTop')}><h1>Datasets</h1><hr /></div>}
-            <input
-              id={'search'}
-              name={'search'}
-              type={'text'}
-              className={`form-control ${css('searchBox')}`}
-              value={searchString}
-              placeholder={'search'}
-              onChange={(e) => { this.handleDatasetSearch(e.target.value) }}
-            />
+            <Search searchString={searchString} onChange={this.handleDatasetSearch} border large style={{width: '50%'}} />
             <Link to={'/dataset/add'} ><button className='btn btn-primary right'>Add</button></Link>
             <hr />
           </header>
@@ -122,17 +115,9 @@ export default class Datasets extends Base {
 
     return (
       <div className={css('wrap')}>
-        <header className={css('header')}>
+        <header>
           { noHeader ? undefined : <div className={css('marginTop')}><h1>Datasets</h1><hr className={css('hr')} /></div>}
-          <input
-            id='search'
-            name='search'
-            type='text'
-            className={`form-control ${css('searchBox')}`}
-            value={searchString}
-            placeholder='search'
-            onChange={(e) => { this.handleDatasetSearch(e.target.value) }}
-          />
+          <Search searchString={searchString} onChange={this.handleDatasetSearch} border large style={{width: '50%'}} />
           <Link to={'/dataset/add'} ><button className='btn btn-primary right'>Add</button></Link>
           <hr />
         </header>
@@ -162,10 +147,6 @@ export default class Datasets extends Base {
         marginTop: 40
       },
       wrap: {
-        paddingLeft: 0,
-        paddingRight: 0
-      },
-      header: {
         paddingLeft: 20,
         paddingRight: 20
       },

--- a/lib/components/Datestamp.js
+++ b/lib/components/Datestamp.js
@@ -97,7 +97,7 @@ export default class Datestamp extends Base {
   }
 
   template (css) {
-    const { dateString, muted, relative } = this.props
+    const { dateString, muted, relative, style } = this.props
     var displayDate
     if (!dateString) {
       displayDate = 'No date information given'
@@ -112,7 +112,7 @@ export default class Datestamp extends Base {
     }
     const displayMuted = muted ? css('muted') : undefined
     return (
-      <div className={`stats ${displayMuted}`} >{displayDate}</div>
+      <div className={`stats ${displayMuted}`} style={style}>{displayDate}</div>
     )
   }
 
@@ -127,6 +127,7 @@ export default class Datestamp extends Base {
 }
 
 Datestamp.propTypes = {
+  style: PropTypes.object,
   palette: Palette,
   dateString: PropTypes.string.isRequired,
   muted: PropTypes.bool,
@@ -134,6 +135,7 @@ Datestamp.propTypes = {
 }
 
 Datestamp.defaultProps = {
+  style: {},
   palette: defaultPalette,
   muted: false,
   relative: false

--- a/lib/components/Hash.js
+++ b/lib/components/Hash.js
@@ -7,7 +7,7 @@ import Base from './Base'
 
 export default class Hash extends Base {
   template (css) {
-    const { hash, short, noPrefix } = this.props
+    const { hash, short, noPrefix, style } = this.props
     var displayHash = hash
     if (displayHash.length < 65) {
       displayHash = 'invalid hash'
@@ -16,7 +16,7 @@ export default class Hash extends Base {
       displayHash = short ? displayHash.slice(0, 2) + '...' + displayHash.slice(-6) : displayHash
     }
     return (
-      <div className={`stats ${css('hash')}`}>{!noPrefix && <span className={css('prefix')}>/ipfs/</span>}{displayHash}</div>
+      <div className={`stats ${css('hash')}`} style={style} >{!noPrefix && <span className={css('prefix')}>/ipfs/</span>}{displayHash}</div>
     )
   }
 
@@ -36,10 +36,12 @@ export default class Hash extends Base {
 Hash.propTypes = {
   short: PropTypes.bool,
   noPrefix: PropTypes.bool,
-  palette: Palette
+  palette: Palette,
+  style: PropTypes.object
 }
 
 Hash.defaultProps = {
+  style: {},
   short: false,
   noPrefix: false,
   palette: defaultPalette

--- a/lib/components/Menu.js
+++ b/lib/components/Menu.js
@@ -21,7 +21,7 @@ export default class Menu extends Base {
           <Link className={css('item', isActive('/datasets'))} to='/datasets'>layers</Link>
           <Link className={css('item', isActive('/peers'))} to='/peers'>usergroup</Link>
           <Link className={css('item', isActive('/profile'))} to={`/profile`}>user</Link>
-          <Link className={css('item', isActive('/navigateright'))} to='/'>navigateright</Link>
+          <Link className={css('item', isActive('/navigateright'))} to='/console'>navigateright</Link>
           <Link className={css('item', isActive('/settings'))} to='/settings'>settings</Link>
           { __BUILD__.MODE !== 'production' && <Link className={css('item', isActive('/stylesheet'))} to='/stylesheet'>settingsfile</Link>}
         </div>

--- a/lib/components/PageHeader.js
+++ b/lib/components/PageHeader.js
@@ -11,7 +11,7 @@ export default class PageHeader extends Base {
     return (
       <div className={css('wrap', padding)}>
         <div>
-          <a className={`left ${css('link')}`} onClick={onGoBack}>◂ Back</a>
+          <a className={`left ${css('link')}`} onClick={onGoBack}><span className='iconInline'>directleft</span> Back</a>
           {this.props.onClickAdd ? <a onClick={this.props.onClickAdd} className={`right ${css('link')}`}>Add </a> : undefined}
           {this.props.exportPath ? <a download={`${name}.zip`} href={`${this.props.exportPath}`} className={`right ${css('link')}`}>Export </a> : undefined}
           {this.props.onClickEdit ? <a onClick={this.props.onClickEdit} className={`right ${css('link')}`}>Edit </a> : undefined}
@@ -31,8 +31,8 @@ export default class PageHeader extends Base {
     const { palette } = props
     return {
       wrap: {
-        paddingTop: 40,
-        paddingBottom: 10
+        paddingTop: 50,
+        fontSize: 20
       },
       paddingLeftRight: {
         paddingLeft: 20,
@@ -41,7 +41,8 @@ export default class PageHeader extends Base {
       hr: {
         borderTop: `1px solid ${palette.a}`,
         display: 'block',
-        width: '100%'
+        width: '100%',
+        marginBottom: 0
       },
       link: {
         marginLeft: '5px',

--- a/lib/components/Peer.js
+++ b/lib/components/Peer.js
@@ -110,14 +110,14 @@ export default class Peer extends Base {
     }
   }
 
-  renderPeerDatasets () {
+  renderPeerDatasets (css) {
     const { namespace, palette } = this.props
     const { loading, message } = this.state
     if (loading) {
       return <Spinner />
     } else {
       return (
-        <div><List
+        <div className={css('wrap')}><List
           data={namespace}
           component={DatasetItem}
           // onSelectItem={this.onSelectDataset}
@@ -178,6 +178,10 @@ export default class Peer extends Base {
       sidebar: {
         width: '30%',
         float: 'right',
+        paddingLeft: 20,
+        paddingRight: 20
+      },
+      wrap: {
         paddingLeft: 20,
         paddingRight: 20
       }

--- a/lib/components/Search.js
+++ b/lib/components/Search.js
@@ -1,0 +1,105 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { Palette, defaultPalette } from '../propTypes/palette'
+
+import Base from './Base'
+
+export default class Search extends Base {
+  constructor (props) {
+    super(props)
+    this.state = {
+      focus: false
+    };
+    [
+      'setFocus',
+      'setBlur'
+    ].forEach((m) => { this[m] = this[m].bind(this) })
+  }
+
+  setFocus (e) {
+    this.setState({focus: true})
+  }
+
+  setBlur (e) {
+    this.setState({focus: false})
+  }
+
+  template (css) {
+    const { searchString, onChange, style, large, border, placeholder } = this.props
+    const { focus } = this.state
+    const displayLarge = large ? 'large' : 'regular'
+    const displayBorder = border ? 'border' : ''
+    const showFocus = focus ? 'focus' : ''
+    const iconFocus = focus ? 'iconFocus' : 'iconColor'
+    return (
+      <div className={`${css('wrap', displayLarge, displayBorder, showFocus)}`} style={style}>
+        <span className={`iconInline ${css(iconFocus)}`}>search</span>
+        <input
+          id='search'
+          name='search'
+          type='text'
+          className={`form-control ${css('searchBox')}`}
+          value={searchString}
+          placeholder={placeholder}
+          onChange={(e) => { onChange(e.target.value) }}
+          onFocus={(e) => this.setFocus(e)}
+          onBlur={(e) => this.setBlur(e)}
+          />
+      </div>
+    )
+  }
+
+  styles (props) {
+    const { palette } = props
+    return {
+      wrap: {
+        transition: 'all 0.25s',
+        borderBottomColor: palette.gray,
+        display: 'inline-block'
+      },
+      border: {
+        borderBottomWidth: 1,
+        borderBottomStyle: 'solid'
+      },
+      regular: {
+        fontSize: 16
+      },
+      large: {
+        fontSize: 22
+      },
+      iconFocus: {
+        color: palette.a
+      },
+      iconColor: {
+        color: palette.gray
+      },
+      focus: {
+        borderBottomColor: palette.a
+      },
+      searchBox: {
+        paddingLeft: 16,
+        display: 'inline-block',
+        width: 'calc(100% - 22px)',
+        border: 'none'
+      }
+    }
+  }
+}
+
+Search.propTypes = {
+  searchString: PropTypes.string,
+  onChange: PropTypes.func,
+  style: PropTypes.object,
+  palette: Palette,
+  placeholder: PropTypes.string
+}
+
+Search.defaultProps = {
+  placeholder: 'search',
+  style: {},
+  palette: defaultPalette,
+  large: false,
+  muted: false,
+  border: false
+}

--- a/lib/components/StatsLine.js
+++ b/lib/components/StatsLine.js
@@ -10,10 +10,10 @@ export default class StatsLine extends Base {
     super(props);
     [
       'renderStat'
-    ].forEach((m) => { this[m] = this[m].bind(m) })
+    ].forEach((m) => { this[m] = this[m].bind(this) })
   }
 
-  renderStat (stat, space, css, index) {
+  renderStat (stat, space, css, index, style) {
     if (stat && stat.value && stat.name) {
       const num = stat.value > 1000 ? Math.round(stat.value / 1000) + 'K' : stat.value
       return <span key={index} className={css(space)}><strong>{num}</strong> {stat.name}</span>
@@ -21,12 +21,12 @@ export default class StatsLine extends Base {
   }
 
   template (css) {
-    const { stats, muted, extraSpace, large } = this.props
+    const { stats, muted, extraSpace, large, style } = this.props
     const space = extraSpace ? 'extraSpace' : 'space'
     const displayLarge = large ? '' : 'stats'
     const displayMuted = muted ? 'muted' : ''
     return (
-      <div className={`${displayLarge} ${displayMuted ? css(displayMuted) : undefined}`}>{stats.map((stat, index) => this.renderStat(stat, space, css, index))}</div>
+      <div className={`${displayLarge} ${displayMuted ? css(displayMuted) : undefined}`} style={style} >{stats.map((stat, index) => this.renderStat(stat, space, css, index))}</div>
     )
   }
 
@@ -50,10 +50,12 @@ StatsLine.propTypes = {
   palette: Palette,
   stats: PropTypes.arrayOf(PropTypes.object).isRequired,
   muted: PropTypes.bool,
-  extraSpace: PropTypes.bool
+  extraSpace: PropTypes.bool,
+  style: PropTypes.object
 }
 
 StatsLine.defaultProps = {
+  style: {},
   palette: defaultPalette,
   stats: [],
   muted: false,

--- a/lib/components/Stylesheet.js
+++ b/lib/components/Stylesheet.js
@@ -10,7 +10,7 @@ import DatasetName from './DatasetName'
 import Datestamp from './Datestamp'
 import StatsLine from './StatsLine'
 import TabPanel from './TabPanel'
-import Search from './search'
+import Search from './Search'
 
 export default class Stylesheet extends Base {
   constructor (props) {

--- a/lib/components/Stylesheet.js
+++ b/lib/components/Stylesheet.js
@@ -10,8 +10,33 @@ import DatasetName from './DatasetName'
 import Datestamp from './Datestamp'
 import StatsLine from './StatsLine'
 import TabPanel from './TabPanel'
+import Search from './search'
 
 export default class Stylesheet extends Base {
+  constructor (props) {
+    super(props)
+    this.state = {
+      searchString1: '',
+      searchString2: '',
+      searchString3: ''
+    };
+    [
+      'handleSearch1',
+      'handleSearch2',
+      'handleSearch3'
+    ].forEach((m) => { this[m] = this[m].bind(this) })
+  }
+
+  handleSearch1 (searchString) {
+    this.setState({searchString1: searchString})
+  }
+  handleSearch2 (searchString) {
+    this.setState({searchString2: searchString})
+  }
+  handleSearch3 (searchString) {
+    this.setState({searchString3: searchString})
+  }
+
   template (css) {
     const { palette, stats } = this.props
     return (
@@ -74,6 +99,9 @@ export default class Stylesheet extends Base {
               <ValidInput type='text' name='input' label='valid input' value='input' showValidation={false} validation='blah' onChange={() => undefined} />
               <ValidInput type='text' name='input' label='invalid input' value='input' showValidation error='blah' onChange={() => undefined} />
               <button className='btn btn-primary'>Primary Button</button>
+              <div><Search onChange={this.handleSearch1} searchString={this.state.searchString1} /></div>
+              <div><Search onChange={this.handleSearch2} searchString={this.state.searchString2} large /></div>
+              <div><Search onChange={this.handleSearch3} searchString={this.state.searchString3} border /></div>
             </div>
             <div className='col-md-6' >
               <DatasetName name='ramfox/comics' />

--- a/lib/components/TabPanel.js
+++ b/lib/components/TabPanel.js
@@ -40,7 +40,7 @@ export default class TabPanel extends Base {
       </div>
     )
   }
-ß
+
   template (css) {
     const { index, expanded, labels = [], components, onSelectPanel, onToggleExpand, search } = this.props
     const panel = (index !== undefined) ? index : this.state.index

--- a/lib/components/TabPanel.js
+++ b/lib/components/TabPanel.js
@@ -40,9 +40,9 @@ export default class TabPanel extends Base {
       </div>
     )
   }
-
+ß
   template (css) {
-    const { index, expanded, labels = [], components, onSelectPanel, onToggleExpand, search} = this.props
+    const { index, expanded, labels = [], components, onSelectPanel, onToggleExpand, search } = this.props
     const panel = (index !== undefined) ? index : this.state.index
     const component = components[panel]
     return (

--- a/lib/components/TabPanel.js
+++ b/lib/components/TabPanel.js
@@ -3,17 +3,21 @@ import PropTypes from 'prop-types'
 import Base from './Base'
 
 import { Palette, defaultPalette } from '../propTypes/palette'
+import Search from './Search'
 
 export default class TabPanel extends Base {
   constructor (props) {
     super(props)
 
     this.state = {
-      index: 0
+      index: 0,
+      searchString: ''
     };
 
     [
-      'handleSetPanel'
+      'handleSetPanel',
+      'setSearch',
+      'renderSearch'
     ].forEach((m) => { this[m] = this[m].bind(this) })
   }
 
@@ -25,8 +29,20 @@ export default class TabPanel extends Base {
     }
   }
 
+  setSearch (searchString) {
+    this.setState({searchString})
+  }
+
+  renderSearch (css) {
+    return (
+      <div className={css('search')}>
+        <Search searchString={this.state.searchString} onChange={this.setSearch} placeholder='search data' />
+      </div>
+    )
+  }
+
   template (css) {
-    const { index, expanded, labels = [], components, onSelectPanel, onToggleExpand } = this.props
+    const { index, expanded, labels = [], components, onSelectPanel, onToggleExpand, search} = this.props
     const panel = (index !== undefined) ? index : this.state.index
     const component = components[panel]
     return (
@@ -38,11 +54,12 @@ export default class TabPanel extends Base {
               <a
                 key={i}
                 className={css('tab', i === panel && 'currentTab')}
-                onClick={this.handleSetPanel.bind(this, i, onSelectPanel)}>{label}</a>
+                onClick={this.handleSetPanel.bind(this, i, onSelectPanel)}><h5>{label}</h5></a>
             )
           }
           )}
         </header>
+        {search ? this.renderSearch(css) : undefined}
         <div className={css('content')}>
           {component}
         </div>
@@ -60,12 +77,15 @@ export default class TabPanel extends Base {
         display: 'flex',
         flexFlow: 'column nowrap'
       },
+      search: {
+        height: 45,
+        paddingLeft: 12
+      },
       tab: {
-        fontWeight: '700',
-        margin: '2px 20px 2px 0',
-        opacity: '0.25',
+        display: 'inline-block',
+        color: palette.gray,
         transition: 'all 0.25s',
-        fontSize: 18
+        marginRight: 40
       },
       expand: {
         float: 'right',
@@ -75,14 +95,13 @@ export default class TabPanel extends Base {
         marginTop: 0
       },
       currentTab: {
-        opacity: '1',
         color: palette.a
       },
       header: {
-        marginLeft: 10,
+        marginLeft: 12,
         marginRight: 10,
         fontWeight: 'bold',
-        padding: '15px 0 0 0',
+        padding: '12px 0 0 0',
         flex: '1 1 50px'
       },
       content: {

--- a/lib/components/form/DateInput.js
+++ b/lib/components/form/DateInput.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import Base from '../Base'
+import { Palette, defaultPalette } from '../../propTypes/palette'
 import MonthCalendar from './MonthCalendar'
 
 /*
@@ -71,17 +72,17 @@ export default class DateInput extends Base {
 
   // Render
   template (css) {
-    const { value } = this.props
+    const { value, className } = this.props
 
     let stringValue = this.stringValue(value)
 
     return (
-      <div className={css('dateInput')}>
+      <div className={`${className} ${css('dateInput')}`}>
         <input
           readOnly
           ref={(el) => { this.field = el }}
           type='text'
-          className='form-control'
+          className={`form-control ${css('border')}`}
           onClick={this.onFocus}
           onTouchEnd={this.onFocus}
           onFocus={this.onFocus}
@@ -101,7 +102,8 @@ export default class DateInput extends Base {
     )
   }
 
-  styles () {
+  styles (props) {
+    const { palette } = this.props
     return {
       dateInput: {
         position: 'relative'
@@ -114,6 +116,15 @@ export default class DateInput extends Base {
         padding: '4px 8px',
         boxShadow: '0 0 4px rgba(0,0,0,0.45)',
         borderRadius: 3
+      },
+      border: {
+        borderColor: palette.gray,
+        ':focus': {
+          borderColor: palette.a
+        }
+      },
+      label: {
+        color: palette.gray
       }
     }
   }
@@ -124,9 +135,11 @@ DateInput.propTypes = {
   // change handler in the form (value, name)
   onChange: PropTypes.func.isRequired,
   // Should be a Date object. Defaults to today.
-  value: PropTypes.instanceOf(Date).isRequired
+  value: PropTypes.instanceOf(Date).isRequired,
+  palette: Palette
 }
 
 DateInput.defaultProps = {
-  value: new Date()
+  value: new Date(),
+  palette: defaultPalette
 }

--- a/lib/components/form/LanguageInput.js
+++ b/lib/components/form/LanguageInput.js
@@ -1,7 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-class LanguageInput extends React.Component {
+import { Palette, defaultPalette } from '../../propTypes/palette'
+import Base from '../Base'
+
+class LanguageInput extends Base {
   constructor (props) {
     super(props)
     this.state = {};
@@ -15,12 +18,11 @@ class LanguageInput extends React.Component {
     this.props.onChange(this.props.name, languages, e)
   }
 
-  render () {
-    const { label, name, value, error, showError, helpText, showHelpText } = this.props
+  template (css) {
+    const { label, name, value, error, showError, helpText, showHelpText, className } = this.props
     return (
-      <div className={(error && showError) ? 'validFormField form-group has-error' : 'validFormField form-group'}>
-        {label && <label className='control-label' htmlFor={name}>{label}</label>}
-        <select id={name} name={name} className='form-control' style={{overflow: 'auto'}} value={value} multiple onChange={(e) => this.handleOnChange(e)}>
+      <div className={(error && showError) ? `validFormField form-group has-error ${className}` : `validFormField form-group ${className}`}>
+        <select id={name} name={name} className={`form-control ${css('border')}`} style={{overflow: 'auto'}} value={value} multiple onChange={(e) => this.handleOnChange(e)}>
           <option value='arabic'>arabic</option>
           <option value='bengali'>bengali</option>
           <option value='chinese'>chinese</option>
@@ -36,10 +38,26 @@ class LanguageInput extends React.Component {
           <option value='russian'>russian</option>
           <option value='spanish'>spanish</option>
         </select>
+        {label && <div><label className={css('label')} htmlFor={name}>{label}</label></div>}
         {(error !== '' && showError) ? <div className='control-label'>{error}</div> : undefined}
-        {(helpText && showHelpText) && <i className='help_hint'>{helpText}</i>}
+        {(helpText && showHelpText) && <div><i className='help_hint'>{helpText}</i></div>}
       </div>
     )
+  }
+
+  styles (props) {
+    const { palette } = props
+    return {
+      border: {
+        borderColor: palette.gray,
+        ':focus': {
+          borderColor: palette.a
+        }
+      },
+      label: {
+        color: palette.gray
+      }
+    }
   }
 }
 
@@ -59,7 +77,8 @@ LanguageInput.propTypes = {
   // weather to show help text or not
   showHelpText: PropTypes.bool,
   // change handler func. will be called with (name, value, event)
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
+  palette: Palette
 }
 
 LanguageInput.defaultProps = {
@@ -67,7 +86,8 @@ LanguageInput.defaultProps = {
   error: undefined,
   showError: true,
   helpText: '',
-  showHelpText: false
+  showHelpText: false,
+  palette: defaultPalette
 }
 
 export default LanguageInput

--- a/lib/components/form/MetadataForm.js
+++ b/lib/components/form/MetadataForm.js
@@ -41,8 +41,8 @@ const MetadataForm = ({ datasetRef, validation, onChange, onCancel, onSubmit, sh
   }
 
   return (
-    <div className='metadata form'>
-      <div className='row'>
+    <div className='metadata form' style={{marginTop: 20}}>
+      <div className=''>
         <ValidInput
           name='title'
           label='Title'
@@ -72,6 +72,7 @@ const MetadataForm = ({ datasetRef, validation, onChange, onCancel, onSubmit, sh
         value={meta.description}
         error={validation.description}
         onChange={onChange}
+        className='col-md-12'
       />
       <TagInput
         name='theme'
@@ -80,6 +81,7 @@ const MetadataForm = ({ datasetRef, validation, onChange, onCancel, onSubmit, sh
         showHelpText={showHelpText}
         value={meta.theme}
         onChange={onChange}
+        className='col-md-12'
       />
       <TagInput
         name='keyword'
@@ -88,8 +90,9 @@ const MetadataForm = ({ datasetRef, validation, onChange, onCancel, onSubmit, sh
         showHelpText={showHelpText}
         value={meta.keyword}
         onChange={onChange}
+        className='col-md-12'
       />
-      <div className='row'>
+      <div className=''>
         <ValidDateTimeInput
           name='modified'
           label='Last Update'
@@ -116,8 +119,9 @@ const MetadataForm = ({ datasetRef, validation, onChange, onCancel, onSubmit, sh
         showHelpText={showHelpText}
         value={meta.identifier}
         onChange={onChange}
+        className='col-md-12'
       />
-      <div className='row'>
+      <div className=''>
         <ValidSelect
           name='accessLevel'
           label='Public Access Level'
@@ -145,6 +149,7 @@ const MetadataForm = ({ datasetRef, validation, onChange, onCancel, onSubmit, sh
         showHelpText={showHelpText}
         value={meta.language}
         onChange={onChange}
+        className='col-md-12'
       />
       <UrlInput
         name='landingPage'
@@ -153,10 +158,16 @@ const MetadataForm = ({ datasetRef, validation, onChange, onCancel, onSubmit, sh
         showHelpText={showHelpText}
         value={meta.landingPage}
         onChange={onChange}
+        className='col-md-12'
       />
-      <br />
-      <input className='btn btn-primary' type='submit' value='Save' onClick={handleShowModal} />
-      <button className='btn' onClick={handleCancel}>Cancel</button>
+      <div className='col-md-12'>
+        <input className='btn btn-primary' type='submit' value='Save' onClick={handleShowModal} />
+        <button className='btn' onClick={handleCancel}>Cancel</button>
+        <br />
+        <br />
+        <br />
+        <br />
+      </div>
     </div>
   )
 }

--- a/lib/components/form/TagInput.js
+++ b/lib/components/form/TagInput.js
@@ -1,8 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-// TODO - work in progress
-class TagInput extends React.Component {
+import { Palette, defaultPalette } from '../../propTypes/palette'
+import Base from '../Base'
+
+export default class TagInput extends Base {
   constructor (props) {
     super(props)
     this.state = { tagString: '' };
@@ -21,24 +23,38 @@ class TagInput extends React.Component {
     this.props.onChange(this.props.name, tags, e)
   }
 
-  render () {
-    const { label, name, showError, error, helpText, placeholder, showHelpText } = this.props
+  template (css) {
+    const { label, name, showError, error, helpText, placeholder, showHelpText, className } = this.props
     return (
-      <div className={(error && showError) ? 'validFormField form-group has-error' : 'validFormField form-group'}>
-        {label ? <label className='control-label' htmlFor={name}>{label}</label> : undefined }
+      <div className={(error && showError) ? `validFormField form-group has-error ${className}` : `validFormField form-group ${className}`}>
         <input
           id={name}
           name={name}
           type='text'
-          className='form-control'
+          className={`form-control ${css('border')}`}
           value={this.state.tagString}
           placeholder={placeholder || name}
           onChange={(e) => this.handleOnChange(e)}
         />
+        {label && <div><label className={css('label')} htmlFor={name}>{label}</label></div>}
         {(error !== '' && showError) ? <div className='control-label'>{error}</div> : undefined}
-        {(helpText && showHelpText) && <i className='help_hint'>{helpText}</i>}
+        {(helpText && showHelpText) && <div><i className='help_hint'>{helpText}</i></div>}
       </div>
     )
+  }
+  styles (props) {
+    const { palette } = props
+    return {
+      border: {
+        borderColor: palette.gray,
+        ':focus': {
+          borderColor: palette.a
+        }
+      },
+      label: {
+        color: palette.gray
+      }
+    }
   }
 }
 
@@ -60,14 +76,14 @@ TagInput.propTypes = {
   // short message to help the user
   helpText: PropTypes.string,
   // weather to show help text or not
-  showHelpText: PropTypes.bool
+  showHelpText: PropTypes.bool,
+  palette: Palette
 }
 
 TagInput.defaultProps = {
   name: undefined,
   error: undefined,
   showError: true,
-  placeholder: ''
+  placeholder: '',
+  palette: defaultPalette
 }
-
-export default TagInput

--- a/lib/components/form/UrlInput.js
+++ b/lib/components/form/UrlInput.js
@@ -6,22 +6,22 @@ import { Palette, defaultPalette } from '../../propTypes/palette'
 
 export default class UrlInput extends Base {
   template (css) {
-    const { label, name, type, showError, error, value, placeholder, onChange, helpText, showHelpText, disabled } = this.props
+    const { label, name, type, showError, error, value, placeholder, onChange, helpText, showHelpText, disabled, className } = this.props
     return (
-      <div className={(error && showError) ? 'validFormField form-group has-error' : 'validFormField form-group'}>
-        {label ? <label className='control-label' htmlFor={name}>{label}</label> : undefined }
+      <div className={(error && showError) ? `validFormField form-group has-error ${className}` : `validFormField form-group ${className}`}>
         <input
           id={name}
           name={name}
           type={type}
-          className='form-control'
+          className={`form-control ${css('border')}`}
           value={value}
           placeholder={placeholder || name}
           onChange={(e) => { onChange(name, e.target.value, e) }}
           disabled={!!disabled}
         />
-        <div className={css('error')}>{error}</div>
-        {(helpText && showHelpText) && <i className='help_hint'>{helpText}</i>}
+        {label && <div><label className={css('label')} htmlFor={name}>{label}</label></div>}
+        {error && <div className={css('error')}>{error}</div>}
+        {(helpText && showHelpText) && <div><i className='help_hint'>{helpText}</i></div>}
       </div>
     )
   }
@@ -33,6 +33,15 @@ export default class UrlInput extends Base {
         margin: '10px',
         color: palette.error,
         fontWeight: '300'
+      },
+      border: {
+        borderColor: palette.gray,
+        ':focus': {
+          borderColor: palette.a
+        }
+      },
+      label: {
+        color: palette.gray
       }
     }
   }

--- a/lib/components/form/ValidDateTimeInput.js
+++ b/lib/components/form/ValidDateTimeInput.js
@@ -3,21 +3,41 @@ import PropTypes from 'prop-types'
 
 import DateInput from './DateInput'
 
-const ValidDateTimeInput = ({ name, value, label, placeholder, disabled, error, showError, helpText, showHelpText, className, onChange }) => {
-  const errorClass = (error && showError) ? 'has-error' : ''
-  return (
-    <div className={`validFormField form-group ${className} ${errorClass}`}>
-      {label && <label className='control-label' htmlFor={name}>{label}</label>}
-      <DateInput
-        name={name}
-        disabled={disabled}
-        placeholder={name}
-        value={value}
-        onChange={onChange}
-      />
-      {(helpText && showHelpText) && <i className='help_hint'>{helpText}</i>}
-    </div>
-  )
+import { Palette, defaultPalette } from '../../propTypes/palette'
+import Base from '../Base'
+
+export default class ValidDateTimeInput extends Base {
+  template (css) {
+    const { name, value, label, placeholder, disabled, error, showError, helpText, showHelpText, className, onChange } = this.props
+    const errorClass = (error && showError) ? 'has-error' : ''
+    return (
+      <div className={`validFormField form-group ${className} ${errorClass}`}>
+        <DateInput
+          name={name}
+          disabled={disabled}
+          placeholder={placeholder || name}
+          value={value}
+          onChange={onChange}
+        />
+        {label && <div><label className={css('label')} htmlFor={name}>{label}</label></div>}
+        {(helpText && showHelpText) && <div><i className='help_hint'>{helpText}</i></div>}
+      </div>
+    )
+  }
+  styles (props) {
+    const { palette } = props
+    return {
+      border: {
+        borderColor: palette.gray,
+        ':focus': {
+          borderColor: palette.a
+        }
+      },
+      label: {
+        color: palette.gray
+      }
+    }
+  }
 }
 
 ValidDateTimeInput.propTypes = {
@@ -42,7 +62,8 @@ ValidDateTimeInput.propTypes = {
   // className will set on the containing div
   className: PropTypes.string,
   // onChange in the form (value, name)
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
+  palette: Palette
 }
 
 ValidDateTimeInput.defaultProps = {
@@ -50,7 +71,6 @@ ValidDateTimeInput.defaultProps = {
   value: new Date(),
   placeholder: '',
   helpText: '',
-  showHelpText: false
+  showHelpText: false,
+  palette: defaultPalette
 }
-
-export default ValidDateTimeInput

--- a/lib/components/form/ValidInput.js
+++ b/lib/components/form/ValidInput.js
@@ -1,23 +1,44 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const ValidInput = ({ label, name, type, value, placeholder, showError, error, helpText, showHelpText, onChange, className }) => {
-  return (
-    <div className={`validFormField form-group ${error && showError && 'has-error'} ${className}`}>
-      {label && <label className='control-label' htmlFor={name}>{label}</label>}
-      <input
-        id={name}
-        name={name}
-        type={type}
-        className='form-control'
-        value={value}
-        placeholder={placeholder || name}
-        onChange={(e) => { onChange(name, e.target.value, e) }}
-      />
-      {(error !== '' && showError) ? <div className='control-label'>{error}</div> : undefined}
-      {(helpText && showHelpText) && <i className='help_hint'>{helpText}</i>}
-    </div>
-  )
+import { Palette, defaultPalette } from '../../propTypes/palette'
+
+import Base from '../Base'
+
+export default class ValidInput extends Base {
+  template (css) {
+    const { label, name, type, value, placeholder, showError, error, helpText, showHelpText, onChange, className } = this.props
+    return (
+      <div className={`validFormField form-group ${error && showError && 'has-error'} ${className}`}>
+        <input
+          id={name}
+          name={name}
+          type={type}
+          className={`form-control ${css('border')}`}
+          value={value}
+          placeholder={placeholder || name}
+          onChange={(e) => { onChange(name, e.target.value, e) }}
+        />
+        {label && <div><label className={css('label')} htmlFor={name}>{label}</label></div>}
+        {(error !== '' && showError) ? <div className='control-label'>{error}</div> : undefined}
+        {(helpText && showHelpText) && <div><i className='help_hint'>{helpText}</i></div>}
+      </div>
+    )
+  }
+  styles (props) {
+    const { palette } = props
+    return {
+      border: {
+        borderColor: palette.gray,
+        ':focus': {
+          borderColor: palette.a
+        }
+      },
+      label: {
+        color: palette.gray
+      }
+    }
+  }
 }
 
 ValidInput.propTypes = {
@@ -41,7 +62,8 @@ ValidInput.propTypes = {
   showHelpText: PropTypes.bool,
   // change handler func. will be called with (name, value, event)
   onChange: PropTypes.func.isRequired,
-  className: PropTypes.string
+  className: PropTypes.string,
+  palette: Palette
 }
 
 ValidInput.defaultProps = {
@@ -52,7 +74,6 @@ ValidInput.defaultProps = {
   error: undefined,
   helpText: '',
   showHelpText: false,
-  className: ''
+  className: '',
+  palette: defaultPalette
 }
-
-export default ValidInput

--- a/lib/components/form/ValidLicenseInput.js
+++ b/lib/components/form/ValidLicenseInput.js
@@ -1,25 +1,46 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const ValidLicenseInput = ({ label, name, className, value, showError, error, helpText, showHelpText, onChange }) => {
-  const errorClass = (error && showError) ? 'has-error' : ''
-  return (
-    <div className={`validFormField ${errorClass} ${className}`}>
-      {label && <label className='control-label' htmlFor={name}>{label}</label>}
-      <select id={name} name={name} className='form-control' value={value} onChange={(e) => { onChange(name, e.target.value, e) }}>
-        <option value='http://www.usa.gov/publicdomain/label/1.0/'>Public Domain</option>
-        <option value='https://creativecommons.org/publicdomain/zero/1.0/'>CC0 - Creative Commons Zero Public Domain Dedication</option>
-        <option value='http://opendatacommons.org/licenses/pddl/1.0/'>PDDL - Open Data Commons Public Domain Dedication and Licence</option>
-        <option value='http://opendatacommons.org/licenses/by/1.0/'>ODC-By - Open Data Commons Attribution License</option>
-        <option value='http://opendatacommons.org/licenses/odbl/1.0/'>ODbL - Open Data Commons Open Database Licens</option>
-        <option value='https://creativecommons.org/licenses/by/4.0/'>CC BY - Creative Commons Attribution</option>
-        <option value='https://creativecommons.org/licenses/by-sa/4.0/'>CC BY-SA - Creative Commons Attribution-ShareAlike</option>
-        <option value='http://www.gnu.org/licenses/fdl-1.3.en.html'>GNU Free Documentation License</option>
-      </select>
-      {(error !== '' && showError) ? <div className='control-label'>{error}</div> : undefined}
-      {(helpText && showHelpText) && <i className='help_hint'>{helpText}</i>}
-    </div>
-  )
+import { Palette, defaultPalette } from '../../propTypes/palette'
+
+import Base from '../Base'
+
+export default class ValidLicenseInput extends Base {
+  template (css) {
+    const { label, name, className, value, showError, error, helpText, showHelpText, onChange } = this.props
+    const errorClass = (error && showError) ? 'has-error' : ''
+    return (
+      <div className={`validFormField ${errorClass} ${className}`}>
+        <select id={name} name={name} className={`form-control ${css('border')}`} value={value} onChange={(e) => { onChange(name, e.target.value, e) }}>
+          <option value='http://www.usa.gov/publicdomain/label/1.0/'>Public Domain</option>
+          <option value='https://creativecommons.org/publicdomain/zero/1.0/'>CC0 - Creative Commons Zero Public Domain Dedication</option>
+          <option value='http://opendatacommons.org/licenses/pddl/1.0/'>PDDL - Open Data Commons Public Domain Dedication and Licence</option>
+          <option value='http://opendatacommons.org/licenses/by/1.0/'>ODC-By - Open Data Commons Attribution License</option>
+          <option value='http://opendatacommons.org/licenses/odbl/1.0/'>ODbL - Open Data Commons Open Database Licens</option>
+          <option value='https://creativecommons.org/licenses/by/4.0/'>CC BY - Creative Commons Attribution</option>
+          <option value='https://creativecommons.org/licenses/by-sa/4.0/'>CC BY-SA - Creative Commons Attribution-ShareAlike</option>
+          <option value='http://www.gnu.org/licenses/fdl-1.3.en.html'>GNU Free Documentation License</option>
+        </select>
+        {label && <div><label className={css('label')} htmlFor={name}>{label}</label></div>}
+        {(error !== '' && showError) ? <div className='control-label'>{error}</div> : undefined}
+        {(helpText && showHelpText) && <div><i className='help_hint'>{helpText}</i></div>}
+      </div>
+    )
+  }
+  styles (props) {
+    const { palette } = props
+    return {
+      border: {
+        borderColor: palette.gray,
+        ':focus': {
+          borderColor: palette.a
+        }
+      },
+      label: {
+        color: palette.gray
+      }
+    }
+  }
 }
 
 ValidLicenseInput.propTypes = {
@@ -40,7 +61,8 @@ ValidLicenseInput.propTypes = {
   // weather to show help text or not
   showHelpText: PropTypes.bool,
   // change handler func. will be called with (name, value, event)
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
+  palette: Palette
 }
 
 ValidLicenseInput.defaultProps = {
@@ -50,7 +72,6 @@ ValidLicenseInput.defaultProps = {
   // https://project-open-data.cio.gov/open-licenses/
   // value: 'http://www.usa.gov/publicdomain/label/1.0/',
   helpText: '',
-  showHelpText: false
+  showHelpText: false,
+  palette: defaultPalette
 }
-
-export default ValidLicenseInput

--- a/lib/components/form/ValidPeriodicityInput.js
+++ b/lib/components/form/ValidPeriodicityInput.js
@@ -1,35 +1,56 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const ValidPeriodicityInput = ({ label, name, className, value, showError, error, helpText, showHelpText, onChange }) => {
-  const errorClass = (error && showError) ? 'has-error' : ''
-  return (
-    <div className={`validFormField ${errorClass} ${className}`}>
-      {label && <label className='control-label' htmlFor={name}>{label}</label>}
-      <select id={name} name={name} className='form-control' value={value} onChange={(e) => { onChange(name, e.target.value, e) }}>
-        <option value=''>Never</option>
-        <option value='R/P1D'>Daily</option>
-        <option value='R/P1W'>Weekly</option>
-        <option value='R/P1M'>Monthly</option>
-        <option value='R/P1Y'>Annually</option>
-        <option value='R/PT1S'>Continuously</option>
-        <option value='R/PT1H'>Hourly</option>
-        <option value='R/P0.33W'>Three times a week</option>
-        <option value='R/P3.5D'>Semiweekly</option>
-        <option value='R/P0.33M'>Three times a Month</option>
-        <option value='R/P2W'>Biweekly</option>
-        <option value='R/P0.5M'>SemiMonthly</option>
-        <option value='R/P2M'>Bimonthly</option>
-        <option value='R/P3M'>Quarterly</option>
-        <option value='R/P4M'>Three Times a year</option>
-        <option value='R/P6M'>Semiannually</option>
-        <option value='R/P2Y'>Biennially</option>
-        <option value='R/P3Y'>Triennially</option>
-      </select>
-      {(error !== '' && showError) ? <div className='control-label'>{error}</div> : undefined}
-      {(helpText && showHelpText) && <i className='help_hint'>{helpText}</i>}
-    </div>
-  )
+import { Palette, defaultPalette } from '../../propTypes/palette'
+
+import Base from '../Base'
+
+export default class ValidPeriodicityInput extends Base {
+  template (css) {
+    const { label, name, className, value, showError, error, helpText, showHelpText, onChange } = this.props
+    const errorClass = (error && showError) ? 'has-error' : ''
+    return (
+      <div className={`validFormField ${errorClass} ${className}`}>
+        <select id={name} name={name} className={`form-control ${css('border')}`} value={value} onChange={(e) => { onChange(name, e.target.value, e) }}>
+          <option value=''>Never</option>
+          <option value='R/P1D'>Daily</option>
+          <option value='R/P1W'>Weekly</option>
+          <option value='R/P1M'>Monthly</option>
+          <option value='R/P1Y'>Annually</option>
+          <option value='R/PT1S'>Continuously</option>
+          <option value='R/PT1H'>Hourly</option>
+          <option value='R/P0.33W'>Three times a week</option>
+          <option value='R/P3.5D'>Semiweekly</option>
+          <option value='R/P0.33M'>Three times a Month</option>
+          <option value='R/P2W'>Biweekly</option>
+          <option value='R/P0.5M'>SemiMonthly</option>
+          <option value='R/P2M'>Bimonthly</option>
+          <option value='R/P3M'>Quarterly</option>
+          <option value='R/P4M'>Three Times a year</option>
+          <option value='R/P6M'>Semiannually</option>
+          <option value='R/P2Y'>Biennially</option>
+          <option value='R/P3Y'>Triennially</option>
+        </select>
+        {label && <div><label className={css('label')} htmlFor={name}>{label}</label></div>}
+        {(error !== '' && showError) ? <div className='control-label'>{error}</div> : undefined}
+        {(helpText && showHelpText) && <div><i className='help_hint'>{helpText}</i></div>}
+      </div>
+    )
+  }
+  styles (props) {
+    const { palette } = props
+    return {
+      border: {
+        borderColor: palette.gray,
+        ':focus': {
+          borderColor: palette.a
+        }
+      },
+      label: {
+        color: palette.gray
+      }
+    }
+  }
 }
 
 ValidPeriodicityInput.propTypes = {
@@ -50,7 +71,8 @@ ValidPeriodicityInput.propTypes = {
   // weather to show help text or not
   showHelpText: PropTypes.bool,
   // change handler func. will be called with (name, value, event)
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
+  palette: Palette
 }
 
 ValidPeriodicityInput.defaultProps = {
@@ -60,7 +82,6 @@ ValidPeriodicityInput.defaultProps = {
   // https://project-open-data.cio.gov/open-licenses/
   value: '',
   helpText: '',
-  showHelpText: false
+  showHelpText: false,
+  palette: defaultPalette
 }
-
-export default ValidPeriodicityInput

--- a/lib/components/form/ValidSelect.js
+++ b/lib/components/form/ValidSelect.js
@@ -1,19 +1,40 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const ValidSelect = ({ label, name, className, options, showError, error, value, helpText, showHelpText, onChange }) => {
-  const errorClass = (error && showError) ? 'has-error' : ''
-  return (
-    <div className={`validFormField form-group ${errorClass} ${className}`}>
-      {label && <label className='control-label' htmlFor={name}>{label}</label> }
-      <select id={name} name={name} className='form-control' value={value} onChange={(e) => { onChange(name, e.target.value, e) }}>
-        <option value='' />
-        {options.map((opt, i) => <option key={i} value={opt}>{opt}</option>)}
-      </select>
-      {(error !== '' && showError) ? <div className='control-label'>{error}</div> : undefined}
-      {(helpText && showHelpText) && <i className='help_hint'>{helpText}</i>}
-    </div>
-  )
+import Base from '../Base'
+import { Palette, defaultPalette } from '../../propTypes/palette'
+
+export default class ValidSelect extends Base {
+  template (css) {
+    const { label, name, className, options, showError, error, value, helpText, showHelpText, onChange } = this.props
+    const errorClass = (error && showError) ? 'has-error' : ''
+    return (
+      <div className={`validFormField form-group ${errorClass} ${className}`}>
+        <select id={name} name={name} className={`form-control ${css('border')}`} value={value} onChange={(e) => { onChange(name, e.target.value, e) }}>
+          <option value='' />
+          {options.map((opt, i) => <option key={i} value={opt}>{opt}</option>)}
+        </select>
+        {label && <div><label className={css('label')} htmlFor={name}>{label}</label></div>}
+        {(error !== '' && showError) ? <div className='control-label'>{error}</div> : undefined}
+        {(helpText && showHelpText) && <div><i className='help_hint'>{helpText}</i></div>}
+      </div>
+    )
+  }
+
+  styles (props) {
+    const { palette } = props
+    return {
+      border: {
+        borderColor: palette.gray,
+        ':focus': {
+          borderColor: palette.a
+        }
+      },
+      label: {
+        color: palette.gray
+      }
+    }
+  }
 }
 
 ValidSelect.propTypes = {
@@ -34,7 +55,8 @@ ValidSelect.propTypes = {
   // weather to show help text or not
   showHelpText: PropTypes.bool,
   // change handler func. will be called with (name, value, event)
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
+  palette: Palette
 }
 
 ValidSelect.defaultProps = {
@@ -42,7 +64,6 @@ ValidSelect.defaultProps = {
   showError: true,
   error: undefined,
   helpText: '',
-  showHelpText: false
+  showHelpText: false,
+  palette: defaultPalette
 }
-
-export default ValidSelect

--- a/lib/components/form/ValidTextarea.js
+++ b/lib/components/form/ValidTextarea.js
@@ -5,10 +5,9 @@ import { Palette, defaultPalette } from '../../propTypes/palette'
 
 export default class ValidTextarea extends Base {
   template (css) {
-    const { label, name, type, value, placeholder, showError, error, helpText, showHelpText, onChange } = this.props
+    const { label, name, type, value, placeholder, showError, error, helpText, showHelpText, onChange, className } = this.props
     return (
-      <div className={(error && showError) ? 'validFormField form-group has-error' : 'validFormField form-group'}>
-        {label && <label className='control-label' htmlFor={name}>{label}</label>}
+      <div className={(error && showError) ? `validFormField form-group has-error ${className}` : `validFormField form-group ${className}`}>
         <textarea
           id={name}
           name={name}
@@ -18,8 +17,9 @@ export default class ValidTextarea extends Base {
           placeholder={placeholder || name}
           onChange={(e) => { onChange(name, e.target.value, e) }}
       />
-        {(error !== '' && showError) ? <div className='control-label'>{error}</div> : undefined }
-        {(helpText && showHelpText) && <i className='help_hint'>{helpText}</i>}
+        {label && <div><label className={css('label')} htmlFor={name}>{label}</label></div>}
+        {(error !== '' && showError) ? <div className='control-label'>{error}</div> : undefined}
+        {(helpText && showHelpText) && <div><i className='help_hint'>{helpText}</i></div>}
       </div>
     )
   }
@@ -33,7 +33,11 @@ export default class ValidTextarea extends Base {
         ':focus': {
           border: `1px solid ${palette.a}`
         }
+      },
+      label: {
+        color: palette.gray
       }
+
     }
   }
 }

--- a/lib/components/item/DatasetItem.js
+++ b/lib/components/item/DatasetItem.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 
 import StatsLine from '../StatsLine'
+import DatasetName from '../DatasetName'
+import Hash from '../Hash'
 import { Palette, defaultPalette } from '../../propTypes/palette'
 import Base from '../Base'
 
@@ -86,10 +88,14 @@ export default class DatasetItem extends Base {
       )
     } else {
       return (
-        <div className='dataset item'>
-          <b className={css('name')}>{data.name || <i>unnamed dataset</i>}</b>{ data.peer ? undefined : <b className={css('name')}>&nbsp;✔</b>}
-          <h3>{(data.dataset && data.dataset.title) || <i>untitled dataset</i>}</h3>
-          <p className={css('path')}>{data.path}</p>
+        <div className={css('wrap', small && 'small')} onMouseEnter={this.handleOnMouseEnter} onMouseLeave={this.handleOnMouseLeave} >
+          <div className='displayInlineBlock'>
+            <DatasetName name={data.name || 'unnamed dataset'} large style={{marginBottom: 15}} />
+            <Hash hash={data.path} style={{marginBottom: 15}} />
+            <h2>{title || 'untitled dataset'}</h2>
+            <StatsLine stats={this.stats(data)} extraSpace large style={{marginTop: 30}} />
+          </div>
+          { data.peer ? this.renderSave(css, data) : undefined}
         </div>
       )
     }
@@ -99,7 +105,7 @@ export default class DatasetItem extends Base {
     const { palette } = props
     return {
       wrap: {
-        margin: 20,
+        margin: '20px 20px 20px 0',
         maxWidth: 820
       },
       small: {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -17,7 +17,8 @@ import PeerContainer from './containers/Peer'
 export default () => (
   <AppContainer>
     <Switch>
-      <Route exact path="/" component={ConsoleContainer} />
+      <Route exact path="/" component={DatasetsContainer} />
+      <Route exact path="/console" component={ConsoleContainer} />
       <Route path="/datasets" component={DatasetsContainer} />
       <Route path="/peers/:id" component={PeerContainer} />
       <Route path="/profile" component={ProfileContainer} />

--- a/lib/scss/_forms.scss
+++ b/lib/scss/_forms.scss
@@ -10,16 +10,17 @@
   // // Make inputs at least the height of their button counterpart (base line-height + padding + border)
   // height: $input-height;
   padding-bottom: ($font-size-base * .5);
-  font-size: ($font-size-base * 1.2);
-  line-height: $input-line-height;
+  //font-size: ($font-size-base * 1.2);
+  //line-height: $input-line-height;
   color: $input-color;
   font-weight: 300;
-  background-color: $input-bg;
+  background-color: transparent;
   // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214.
   background-image: none;
   background-clip: padding-box;
   border: none;
-  border-bottom: $input-border-width solid $input-border-color;
+  border-bottom-width: $input-border-width;
+  border-bottom-style: solid;
   // overflow: auto;
   // Note: This has no effect on <select>s in some browsers, due to the limited stylability of `<select>`s in CSS.
   @include box-shadow($input-box-shadow);
@@ -31,7 +32,7 @@
     border: 0;
   }
   &:focus {
-    border-bottom-color: $input-border-focus;
+    //border-bottom-color: $input-border-focus;
     outline: none;
   }
 

--- a/lib/scss/_site.scss
+++ b/lib/scss/_site.scss
@@ -103,6 +103,15 @@ b {
   // }
 }
 
+.iconInline {
+  font-family: 'SSPika';
+  display: inline-block;
+  text-align: center;
+  text-decoration: none;
+  margin-top: 10px;
+  transition: all 0.25s;
+}
+
 ::-webkit-scrollbar {
   width: 8px;
   background-color: transparent;

--- a/lib/scss/_type.scss
+++ b/lib/scss/_type.scss
@@ -93,7 +93,6 @@ h6, .h6 {
 
 .inline-block {
   display: inline-block;
-  margin-right: 10px;
 }
 
 // Type display classes
@@ -246,7 +245,7 @@ label {
   line-height: 22px;
 }
 .stats {
-  font-family: $font-family-sans-serif;
+  font-family: $font-family-monospace;
   font-weight: $font-weight-regular;
   font-size: 14px;
   line-height: 22px;


### PR DESCRIPTION
closes #195 
- [x] using basic components, compose datasetHeader to match sketch document
- [x] add 'style' property that allows adding margins/padding to basic components for easier composition 

closes #196 
- [x] create search component, takes in searchString and onChange func
- [x] add options: large (vs regular), border (just bottom border), placeholder string
- [x] add to Tab panel (looks good, but commented out for now. Probably doesn't belong in tab panel, probably belongs in the component below tab panel)
- [x] add to Datasets page

closes #197 
- [x] ValidTextArea
- [x] ValidSelect
- [x] ValidPeriodicityInput
- [x] ValidLicenseInput
- [x] ValidInput
- [x] ValidDateTimeInput
- [x] UrlInput
- [x] TagInput
- [x] MonthCalendar
- [x] Language Input
- [x] DropFile
- [x] DateInput


closes #198
- [x] change routes so dataset page is landing page