### PR TITLE
fix(*): fix bugs on Peer page, metadata, dataset save modal, datasets reload button

### DIFF
--- a/lib/actions/dataset.js
+++ b/lib/actions/dataset.js
@@ -258,7 +258,7 @@ export function saveDataset (datasetRef, callback) {
         callback()
         dispatch(setMessage('dataset updated'))
         setTimeout(() => dispatch(resetMessage()), 5000)
-        const path = action.response.result
+        const path = action.response.result.data
         return dispatch(push(`/dataset/${path.slice(6, -13)}`))
       }
       callback()

--- a/lib/components/Dataset.js
+++ b/lib/components/Dataset.js
@@ -12,6 +12,7 @@ import DatasetHeader from './DatasetHeader'
 import Structure from './Structure'
 import CommitsContainer from '../containers/Commits'
 import NameDataset from './NameDataset'
+import Spinner from './Spinner'
 
 const RENAME_DATASET_MODAL = 'RENAME_DATASET_MODAL'
 
@@ -240,6 +241,10 @@ export default class Dataset extends Base {
           <p>No Dataset</p>
         </div>
       )
+    }
+
+    if (datasetRef && datasetRef.dataset && datasetRef.dataset.structure && typeof datasetRef.dataset.structure === 'string') {
+      return (<Spinner />)
     }
 
     const { dataset, path, name, peer } = datasetRef

--- a/lib/components/Dataset.js
+++ b/lib/components/Dataset.js
@@ -27,6 +27,7 @@ export default class Dataset extends Base {
     };
 
     [
+      'handleLoadDatasetData',
       'handleLoadMoreResults',
       'handleDownloadDataset',
       'handleDeleteDataset',
@@ -48,7 +49,11 @@ export default class Dataset extends Base {
 
   componentWillMount () {
     this.props.loadDataset(this.props.path)
-    this.props.loadDatasetData(this.props.path, (error) => {
+    this.handleLoadDatasetData(this.props.path)
+  }
+
+  handleLoadDatasetData (path) {
+    this.props.loadDatasetData(path, (error) => {
       if (error) {
         this.setState({loading: false, error: error})
       }
@@ -180,7 +185,9 @@ export default class Dataset extends Base {
         data={data}
         onLoadMore={this.handleLoadMoreResults}
         onSetLoadingData={this.handleSetLoadingData}
+        onReload={this.handleLoadDatasetData}
         loading={loading}
+        path={datasetRef && datasetRef.path}
         error={error}
       />
     )

--- a/lib/components/DatasetDataGrid.js
+++ b/lib/components/DatasetDataGrid.js
@@ -8,13 +8,16 @@ import { datasetProps } from '../propTypes/datasetRefProps.js'
 import Spinner from '../components/Spinner'
 import defaultColumnWidths from '../utils/defaultColumnWidths'
 
+import Base from './Base'
+import { Palette, defaultPalette } from '../propTypes/palette'
+
 function timeout (duration = 0) {
   return new Promise((resolve, reject) => {
     setTimeout(resolve, duration)
   })
 }
 
-class DatasetDataGrid extends React.Component {
+class DatasetDataGrid extends Base {
   constructor (props) {
     super(props)
 
@@ -132,7 +135,11 @@ class DatasetDataGrid extends React.Component {
     return { left, top: field.top }
   }
 
-  render () {
+  handleOnReload () {
+    this.props.onReload(this.props.path)
+  }
+
+  template (css) {
     const { dataset, data, width, height } = this.props
     const { field } = this.state
 
@@ -142,13 +149,16 @@ class DatasetDataGrid extends React.Component {
       )
     } else if (this.props.error) {
       return (
-        <div className='panel'>
+        <div className={css('panel')}>
           <label>Error loading data</label>
+          {/* TODO reload button
+          <div><button className={`btn btn-primary ${css('reload')}`} onClick={onReload} >reload data</button></div>
+          */}
         </div>
       )
     } else if (!dataset) {
       return (
-        <div className='panel'>
+        <div className={css('panel')}>
           <label>Run a query to view data</label>
         </div>
       )
@@ -179,6 +189,17 @@ class DatasetDataGrid extends React.Component {
       </div>
     )
   }
+
+  styles (props) {
+    return {
+      panel: {
+        margin: 20
+      },
+      reload: {
+        marginTop: 20
+      }
+    }
+  }
 }
 
 DatasetDataGrid.propTypes = {
@@ -188,10 +209,12 @@ DatasetDataGrid.propTypes = {
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
   height: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
   loading: PropTypes.bool.isRequired,
-  error: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
+  error: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  palette: Palette
 }
 
 DatasetDataGrid.defaultProps = {
+  palette: defaultPalette
 }
 
 export default DatasetDataGrid

--- a/lib/components/Datasets.js
+++ b/lib/components/Datasets.js
@@ -96,7 +96,7 @@ export default class Datasets extends Base {
   }
 
   template (css) {
-    const { message, loading } = this.state
+    const { message, loading, error } = this.state
     const { datasets, searchString, noHeader, palette, smallItems, statItem, showStats } = this.props
 
     return (
@@ -124,8 +124,7 @@ export default class Datasets extends Base {
               type='datasets'
               />
             }
-            {/* TODO add back reload datasets button
-            this.state.error ? <button className={`btn btn-primary`} onClick={this.handlReloadDatasets} >reload datasets</button> : undefined */}
+            {error ? <button className={`btn btn-primary ${css('reload')}`} onClick={this.handleReloadDatasets} >reload datasets</button> : undefined }
           </div>
           {showStats ? <div className='col-md-4'>
             <List data={statItem} component={StatItem} />
@@ -156,6 +155,9 @@ export default class Datasets extends Base {
       },
       hr: {
         marginTop: 0
+      },
+      reload: {
+        marginBottom: 40
       }
     }
   }

--- a/lib/components/Peer.js
+++ b/lib/components/Peer.js
@@ -138,26 +138,28 @@ export default class Peer extends Base {
       return (<Spinner />)
     }
     return (
-      <div className={css('wrap')}>
+      <div>
         <PeerHeader
           onGoBack={this.handleGoBack}
           setPosterPhoto={profile && this.handleSetPosterPhoto}
           setProfilePhoto={profile && this.handleSetProfilePhoto}
           peer={peer}
         />
-        <div className={css('main')}>
-          <div className={css('sidebar')}>
-            <PeerSidebar peer={peer} />
-          </div>
-          <div className={css('content')}>
-            <TabPanel
-              index={tabIndex}
-              labels={['Datasets']}
-              onSelectPanel={this.changeTabIndex}
-              components={[
-                this.renderPeerDatasets(css)
-              ]}
-              />
+        <div className={css('wrap')}>
+          <div className={css('main')}>
+            <div className={css('sidebar')}>
+              <PeerSidebar peer={peer} />
+            </div>
+            <div className={css('content')}>
+              <TabPanel
+                index={tabIndex}
+                labels={['Datasets']}
+                onSelectPanel={this.changeTabIndex}
+                components={[
+                  this.renderPeerDatasets(css)
+                ]}
+                />
+            </div>
           </div>
         </div>
       </div>

--- a/lib/components/Peer.js
+++ b/lib/components/Peer.js
@@ -131,7 +131,7 @@ export default class Peer extends Base {
   }
 
   template (css) {
-    const { peer } = this.props
+    const { peer, profile } = this.props
     const { tabIndex } = this.state
 
     if (!peer) {
@@ -141,8 +141,8 @@ export default class Peer extends Base {
       <div className={css('wrap')}>
         <PeerHeader
           onGoBack={this.handleGoBack}
-          setPosterPhoto={this.handleSetPosterPhoto}
-          setProfilePhoto={this.handleSetProfilePhoto}
+          setPosterPhoto={profile && this.handleSetPosterPhoto}
+          setProfilePhoto={profile && this.handleSetProfilePhoto}
           peer={peer}
         />
         <div className={css('main')}>
@@ -190,6 +190,7 @@ export default class Peer extends Base {
 }
 
 Peer.propTypes = {
+  profile: PropTypes.bool,
   loadPeer: PropTypes.func.isRequired,
   loadPeerNamespace: PropTypes.func.isRequired,
   setPosterPhoto: PropTypes.func,
@@ -208,5 +209,6 @@ Peer.propTypes = {
 }
 
 Peer.defaultProps = {
-  palette: defaultPalette
+  palette: defaultPalette,
+  profile: false
 }

--- a/lib/components/PeerHeader.js
+++ b/lib/components/PeerHeader.js
@@ -149,8 +149,8 @@ export default class PeerHeader extends Base {
 PeerHeader.propTypes = {
   onGoBack: PropTypes.func.isRequired,
   peer: PropTypes.object.isRequired,
-  setPosterPhoto: PropTypes.func,
-  setProfilePhoto: PropTypes.func,
+  setPosterPhoto: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
+  setProfilePhoto: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
 
   palette: Palette
 }

--- a/lib/components/PeerSidebar.js
+++ b/lib/components/PeerSidebar.js
@@ -16,8 +16,8 @@ export default class PeerSidebar extends Base {
           { /* TODO - these links break errrrythang peer.homeUrl ? <p><a href={peer.homeUrl}>{peer.homeUrl}</a></p> : undefined */ }
           { peer.homeUrl ? <p>{peer.homeUrl}</p> : undefined }
           { /* TODO - peer.twitter ? <p><a href={`https://twitter.com/${peer.twitter}`}>{peer.twitter}</a></p> : undefined */ }
-          { peer.twitter ? <p>{peer.twitter}</p> : undefined }
-          { peer.email ? <p>{peer.email}</p> : undefined }
+          { peer.twitter ? <p><b>twitter:</b> {peer.twitter}</p> : undefined }
+          { peer.email ? <p><b>email:</b> {peer.email}</p> : undefined }
           { peer.description ? <p>{peer.description}</p> : undefined}
         </div>
       </div>
@@ -28,7 +28,6 @@ export default class PeerSidebar extends Base {
     const { palette } = props
     return {
       wrap: {
-        marginTop: 40
       },
       hr: {
         borderTop: `1px solid ${palette.overlay}`,

--- a/lib/components/form/SaveMetadataForm.js
+++ b/lib/components/form/SaveMetadataForm.js
@@ -19,23 +19,13 @@ export default class SaveMetadataForm extends Base {
 
     [
       'handleOnChange',
-      'handleDisableButton',
       'handleClickCancel',
       'handleClickSave'
     ].forEach((m) => { this[m] = this[m].bind(this) })
   }
 
   handleOnChange (name, value, e) {
-    this.setState({ [name]: value }, this.handleDisableButton)
-  }
-
-  handleDisableButton () {
-    const { description } = this.state
-    if (description) {
-      this.setState({ disabled: false })
-    } else {
-      this.setState({ disabled: true })
-    }
+    this.setState({ [name]: value, disabled: !value })
   }
 
   handleClickCancel () {

--- a/lib/containers/Profile.js
+++ b/lib/containers/Profile.js
@@ -28,7 +28,8 @@ const ProfileContainer = connect(
       loading: selectIsFetching(state, paginationSection, paginationNode),
       nextPage: selectPageCount(state, paginationSection, paginationNode) + 1,
       fetchedAll: selectFetchedAll(state, paginationSection, paginationNode),
-      connected: selectConnected(state, path)
+      connected: selectConnected(state, path),
+      profile: true
     }, ownProps)
   }, {
     loadPeer: loadSessionUser,

--- a/lib/scss/_modal.scss
+++ b/lib/scss/_modal.scss
@@ -5,6 +5,7 @@
 	position: absolute;
 	top: 0;
 	left: 0;
+	z-index: 101;
 
 	.modal {
 		z-index: 5;


### PR DESCRIPTION
closes #218 
- don't render options for changing photos on a peer's page

closes #221 
closes #228
- saving metadata brings you to the updated dataset page
- fixed bug that sometimes did not enable the save button on the save metadata modal page

closes #226 
- changed the z-index on the modal-wrap to cover the data column headers

closes #166 
- added back reload button, fixed dumb bug

closes #224 
- add structure to email/twitter section of profile

laid groundwork for #231 (adding reload data button)