### PR TITLE
fix(data): need dataPath to correctly select the dataset's data

### DIFF
--- a/lib/actions/dataset.js
+++ b/lib/actions/dataset.js
@@ -3,7 +3,7 @@ import { push } from 'react-router-redux'
 
 import { CALL_API } from '../middleware/api'
 import Schemas from '../schemas'
-import { selectDatasetByPath } from '../selectors/dataset'
+import { selectDatasetByPath, selectDatasetData } from '../selectors/dataset'
 import { newLocalModel, updateLocalModel, removeLocalModel } from './locals'
 import { setMessage, setErrorMessage, resetMessage, clearPagination } from './app'
 
@@ -144,7 +144,7 @@ export function fetchDatasetData (path, page = 1, pageSize = 100) {
 }
 
 export function loadDatasetData (path, callback, page = 1, pageSize = 100) {
-  return (dispatch) => {
+  return (dispatch, getState) => {
     // const dataset = selectDatasetByAddress(getState(), address)
     // if (dataset.schema != null) {
     //  return null
@@ -152,7 +152,9 @@ export function loadDatasetData (path, callback, page = 1, pageSize = 100) {
     // if (dataset && requiredFields.every(key => dataset.hasOwnProperty(key))) {
     //   return null
     // }
-
+    if (selectDatasetData(getState(), path)) {
+      return null
+    }
     return dispatch(
       fetchDatasetData(path, page, pageSize)
     ).then(action => {

--- a/lib/components/Dataset.js
+++ b/lib/components/Dataset.js
@@ -204,7 +204,7 @@ export default class Dataset extends Base {
           data={data}
           datasetRef={datasetRef}
           loading={loading}
-          error={error}
+          error={!!error}
           onClick={this.handleReload}
           onSetLoadingData={this.handleSetLoadingData}
         />

--- a/lib/containers/Dataset.js
+++ b/lib/containers/Dataset.js
@@ -33,12 +33,13 @@ const DatasetContainer = connect(
       datasetRef = selectDatasetByPath(state, id)
       isLatestDataset = false
     }
+    const dataPath = datasetRef && datasetRef.dataset && datasetRef.dataset.dataPath
     return Object.assign({
       isLatestDataset,
       path,
       id,
       datasetRef,
-      data: selectDatasetData(state, id),
+      data: selectDatasetData(state, dataPath),
       history: ownProps.history,
       goBack: ownProps.history.goBack
     }, state.console, ownProps)


### PR DESCRIPTION
related to issue #263 

matches bug fix from issue qri-io/qri #310, we need to store dataset data using the data's hash not the dataset hash