### PR TITLE
fix(dataset): remove ability for peer to edit dataset that they did not add

### DIFF
--- a/lib/actions/dataset.js
+++ b/lib/actions/dataset.js
@@ -202,7 +202,7 @@ export function deleteDataset (datasetRef, redirectUrl = '/') {
         // redirect
         dispatch(push(redirectUrl))
         // and set a message with a timeout
-        dispatch(setMessage('dataset deleted'))
+        dispatch(setMessage('dataset removed from your qri node'))
         setTimeout(() => {
           dispatch(resetMessage())
         }, 5000)

--- a/lib/components/Dataset.js
+++ b/lib/components/Dataset.js
@@ -80,7 +80,7 @@ export default class Dataset extends Base {
   handleDeleteDataset (datasetRef, peer) {
     if (!peer) {
       return () => {
-        if (confirm('are you sure you want to delete this dataset?')) {
+        if (confirm('are you sure you want to remove this dataset from your qri node? (Note: if this dataset has been added by other peers, the data may still exist on the network)')) {
           this.props.deleteDataset(datasetRef, '/')
         }
       }
@@ -104,28 +104,38 @@ export default class Dataset extends Base {
   }
 
   handleEditMetadata () {
-    const { peername, name, datasetRef, peer } = this.props
+    // const { peername, name, datasetRef, peer } = this.props
+    const { peername, name, datasetRef } = this.props
     const { path } = datasetRef
-    if (!peer) {
+    // temporary fix: don't allow users to edit datasets that they
+    // did not create
+    const edit = this.props.sessionProfileName === this.props.peername
+    if (edit) {
       return () => this.props.history.push(`/${peername}/${name}/at${path}/meta/edit`)
-    } else {
-      return undefined
     }
+    return undefined
   }
 
   handleRenameDataset (datasetRef, newName, callback) {
     this.props.renameDataset(datasetRef, newName).then(action => callback(action))
   }
 
-  handleShowRenameModal (peer, datasetRef) {
-    return !peer ? () => {
-      const data = {
-        datasetRef,
-        handleNameDataset: this.handleRenameDataset,
-        hideModal: this.props.hideModal
+  // handleShowRenameModal (peer, datasetRef) {
+  handleShowRenameModal (datasetRef) {
+    // temporary fix: don't allow users to edit datasets that they
+    // did not create
+    const edit = this.props.sessionProfileName === this.props.peername
+    if (edit) {
+      return () => {
+        const data = {
+          datasetRef,
+          handleNameDataset: this.handleRenameDataset,
+          hideModal: this.props.hideModal
+        }
+        this.props.showModal(RENAME_DATASET_MODAL, this, data, false)
       }
-      this.props.showModal(RENAME_DATASET_MODAL, this, data, false)
-    } : undefined
+    }
+    return undefined
   }
 
   handleDescription (dataset) {
@@ -146,7 +156,7 @@ export default class Dataset extends Base {
 
   renderMeta (css, dataset, peer) {
     if (dataset.meta) {
-      return (<div className={css('overflow')} ><Meta meta={dataset.meta} onClickEdit={this.handleEditMetadata()} peer={peer} /></div>)
+      return (<div className={css('overflow')} ><Meta meta={dataset.meta} onClickEdit={this.handleEditMetadata()} /></div>)
     } else {
       return (<p>This dataset currently has no specified metadata</p>)
     }
@@ -278,7 +288,8 @@ export default class Dataset extends Base {
                 exportPath={this.handleDownloadDataset(peername, name, peer)}
                 onGoBack={this.handleGoBack}
                 onClickAdd={this.handleAddDataset(peername, name, peer)}
-                onClickRename={this.handleShowRenameModal(peer, datasetRef)}
+                // onClickRename={this.handleShowRenameModal(peer, datasetRef)}
+                onClickRename={this.handleShowRenameModal(datasetRef)}
                 peer={peer}
                 description={this.handleDescription(dataset)}
                 isLatestDataset={isLatestDataset}

--- a/lib/components/DatasetHeader.js
+++ b/lib/components/DatasetHeader.js
@@ -70,7 +70,7 @@ export default class DatasetHeader extends Base {
             {this.renderDescription(css)}
           </div>
           <div className={css('buttons')}>
-            { onClickDelete ? <span className={css('button')}><Button text='Delete' onClick={onClickDelete} color='d' name='delete' /></span> : undefined }
+            { onClickDelete ? <span className={css('button')}><Button text='Remove' onClick={onClickDelete} color='d' name='remove' /></span> : undefined }
             { onClickAdd ? <span className={css('button')}><Button text='Add' onClick={onClickAdd} color='a' name='add' /></span> : undefined }
             { exportPath ? <span className={css('button')}><Button color='c' text='Export' downloadName={datasetRef.name} download={exportPath} /></span> : undefined }
           </div>

--- a/lib/components/meta.js
+++ b/lib/components/meta.js
@@ -7,7 +7,7 @@ import Button from './Button'
 
 export default class Meta extends Base {
   template (css) {
-    const { meta, onClickEdit, peer } = this.props
+    const { meta, onClickEdit } = this.props
     let md = meta
     if (typeof meta === 'string') {
       md = {path: meta}
@@ -15,7 +15,7 @@ export default class Meta extends Base {
     return (
       <div className={css('flex')}>
         <Json data={md} />
-        {peer ? undefined : <Button color='e' text='Edit' name='Edit' onClick={onClickEdit} />}
+        {onClickEdit ? <Button color='e' text='Edit' name='Edit' onClick={onClickEdit} /> : undefined}
       </div>
     )
   }
@@ -33,8 +33,7 @@ export default class Meta extends Base {
 
 Meta.propTypes = {
   meta: MetaProps,
-  onClickEdit: PropTypes.func,
-  peer: PropTypes.bool
+  onClickEdit: PropTypes.func
 }
 
 Meta.defaultProps = {

--- a/lib/containers/Dataset.js
+++ b/lib/containers/Dataset.js
@@ -35,6 +35,7 @@ const DatasetContainer = connect(
       datasetRef,
       path,
       datapath,
+      sessionProfileName: selectSessionProfilename(state),
       peer: !selectIsSessionDataset(state, datasetRef),
       data: selectDatasetData(state, datapath),
       noData: selectNoDatasetData(state, 'datasetData', datapath),


### PR DESCRIPTION

For now, unless you added the dataset to qri, you are not able to rename or edit the metadata on the frontend. This by passes some errors we are getting when a peer makes a save on a dataset that they did not add.

Also changed "delete" to "remove" and added some more explanation when you remove a dataset, as a start.