### PR TITLE
feat(AddDataset): AddDataset can now take a dataset .yaml or .json file as well as a body file

### DIFF
--- a/lib/actions/dataset.js
+++ b/lib/actions/dataset.js
@@ -242,7 +242,7 @@ export function downloadDataset (datasetRef) {
   }
 }
 
-export function initDataset (name, files, url) {
+export function initDataset (name, file, body, url) {
   return (dispatch) => {
     return dispatch({
       [CALL_API]: {
@@ -252,7 +252,7 @@ export function initDataset (name, files, url) {
         schema: Schemas.DATASET,
         silentError: true,
         data: { name, url, peername: 'me' },
-        files
+        files: {file, body}
       }
     }).then(action => {
       if (action.type === DATASET_INIT_FAILURE) {

--- a/lib/actions/session.js
+++ b/lib/actions/session.js
@@ -81,7 +81,7 @@ export function setProfilePhoto (files) {
         method: 'PUT',
         schema: Schemas.PROFILE,
         data: {},
-        files
+        files: {file: files}
       }
     }).then(() => {
       dispatch(loadSessionProfile())
@@ -98,7 +98,7 @@ export function setProfilePoster (files) {
         method: 'PUT',
         schema: Schemas.PROFILE,
         data: {},
-        files
+        files: {file: files}
       }
     }).then(() => {
       dispatch(loadSessionProfile())

--- a/lib/components/AddDataset.js
+++ b/lib/components/AddDataset.js
@@ -27,7 +27,7 @@ export default class AddDataset extends Base {
         url: '',
         file: undefined,
         body: undefined,
-        body_input: undefined
+        bodyInput: undefined
       },
       radio: 'file'
     };
@@ -51,7 +51,7 @@ export default class AddDataset extends Base {
   }
 
   handleChange (name, value, e) {
-    let bodyInput = this.state.dataset.body_input
+    let bodyInput = this.state.dataset.bodyInput
     if (e.target.type === 'file') {
       bodyInput = e.target
     }
@@ -59,7 +59,7 @@ export default class AddDataset extends Base {
       return
     }
     this.setState(Object.assign({}, this.state, {
-      dataset: Object.assign({}, this.state.dataset, { [name]: value, body_input: bodyInput })
+      dataset: Object.assign({}, this.state.dataset, { [name]: value, bodyInput: bodyInput })
     }))
   }
 

--- a/lib/components/AddDataset.js
+++ b/lib/components/AddDataset.js
@@ -24,8 +24,9 @@ export default class AddDataset extends Base {
       dataset: {
         name: '',
         url: '',
-        files: undefined,
-        file_input: undefined
+        file: undefined,
+        body: undefined,
+        body_input: undefined
       }
     };
 
@@ -47,15 +48,15 @@ export default class AddDataset extends Base {
   }
 
   handleChange (name, value, e) {
-    let fileInput = this.state.dataset.file_input
+    let bodyInput = this.state.dataset.body_input
     if (e.target.type === 'file') {
-      fileInput = e.target
+      bodyInput = e.target
     }
     if (name === 'name' && value.slice(-1) === ' ') {
       return
     }
     this.setState(Object.assign({}, this.state, {
-      dataset: Object.assign({}, this.state.dataset, { [name]: value, file_input: fileInput })
+      dataset: Object.assign({}, this.state.dataset, { [name]: value, body_input: bodyInput })
     }))
   }
 
@@ -92,7 +93,7 @@ export default class AddDataset extends Base {
     const { dataset } = this.state
     e.preventDefault()
     this.setState({ loading: true, message: '' })
-    this.props.initDataset(dataset.name, dataset.files, dataset.url).then(action => this.onDatasetAddResponse(action))
+    this.props.initDataset(dataset.name, dataset.file, dataset.body, dataset.url).then(action => this.onDatasetAddResponse(action))
   }
 
   handleValidateUrl (url) {
@@ -110,7 +111,7 @@ export default class AddDataset extends Base {
 
   handleButtonToggle () {
     const { dataset, urlError } = this.state
-    let enable = !!dataset.name && ((dataset.url.length > 7 && !urlError) || dataset.files)
+    let enable = !!dataset.name && ((dataset.url.length > 7 && !urlError) || dataset.file, dataset.body)
     this.setState({disabled: !enable})
   }
 
@@ -128,9 +129,10 @@ export default class AddDataset extends Base {
           <div className={css('name')}>
             <ValidInput type='text' name='name' label='Dataset Name' value={dataset.name} onChange={this.handleChange} />
           </div>
-          <UrlInput type='text' name='url' label='Add Dataset From URL' value={dataset.url} onChange={this.handleUrlChange} error={this.state.urlError} disabled={this.state.dataset.files} />
+          <UrlInput type='text' name='url' label='Add Dataset From URL' value={dataset.url} onChange={this.handleUrlChange} error={this.state.urlError} disabled={this.state.dataset.file} />
           <div>OR</div>
-          <DropFile name='files' onChange={this.handleChange} label='Add Dataset From Upload' disabled={this.state.dataset.url} csv json />
+          <DropFile name='body' onChange={this.handleChange} label='Add Body From Upload' disabled={this.state.dataset.url} csv json />
+          <DropFile name='file' onChange={this.handleChange} label='Add Dataset From Upload' yaml json />
           <div className={css('buttonWrap')}>
             <Button loading={loading} disabled={disabled} onClick={this.handleSubmit} text='Add Dataset' name='add-dataset' />
             <div className={css('message')}>{loading ? undefined : message }</div>

--- a/lib/components/AddDataset.js
+++ b/lib/components/AddDataset.js
@@ -10,6 +10,7 @@ import DropFile from './form/DropFile'
 import ValidInput from './form/ValidInput'
 import UrlInput from './form/UrlInput'
 import Button from './Button'
+import RadioInput from './form/RadioInput'
 
 import { DATASET_INIT_SUCCESS } from '../constants/dataset'
 
@@ -27,7 +28,8 @@ export default class AddDataset extends Base {
         file: undefined,
         body: undefined,
         body_input: undefined
-      }
+      },
+      radio: 'file'
     };
 
     [
@@ -37,6 +39,7 @@ export default class AddDataset extends Base {
       'handleChange',
       'handleSubmit',
       'handleUrlChange',
+      'handleRadioChange',
       'handleValidateUrl',
       'handleButtonToggle'
     ].forEach((m) => { this[m] = this[m].bind(this) })
@@ -104,6 +107,10 @@ export default class AddDataset extends Base {
     }
   }
 
+  handleRadioChange (e) {
+    this.setState({radio: e.target.value})
+  }
+
   handleUrlChange (name, value, e) {
     this.debounceValidateUrl(value)
     this.handleChange(name, value, e)
@@ -124,15 +131,25 @@ export default class AddDataset extends Base {
     return (
       <div className={css('wrap')}>
         <h1>Add a Dataset</h1>
-        <hr />
         <div>
           <div className={css('name')}>
-            <ValidInput type='text' name='name' label='Dataset Name' value={dataset.name} onChange={this.handleChange} />
+            <div className={css('datasetNameText')}>My new dataset is called </div><ValidInput type='text' name='name' label='Dataset Name' value={dataset.name} onChange={this.handleChange} inline />
           </div>
-          <UrlInput type='text' name='url' label='Add Dataset From URL' value={dataset.url} onChange={this.handleUrlChange} error={this.state.urlError} disabled={this.state.dataset.file} />
-          <div>OR</div>
-          <DropFile name='body' onChange={this.handleChange} label='Add Body From Upload' disabled={this.state.dataset.url} csv json />
-          <DropFile name='file' onChange={this.handleChange} label='Add Dataset From Upload' yaml json />
+          <div className={css('bodyWrap')}>
+            <div className={css('bodyText')}>
+            I want Qri to get the body of the dataset from a <RadioInput name='body' value='file' text='file' color='a' onChange={this.handleRadioChange} defaultChecked /> or <RadioInput name='body' value='url' text='url' color='a' onChange={this.handleRadioChange} />
+            </div>
+            <div className={this.state.radio === 'url' ? css('block') : css('none')}>
+              <UrlInput type='text' name='url' label='Add Dataset From URL' value={dataset.url} onChange={this.handleUrlChange} error={this.state.urlError} disabled={this.state.dataset.file} />
+            </div>
+            <div className={this.state.radio === 'file' ? css('block') : css('none')}>
+              <DropFile name='body' onChange={this.handleChange} label='Add Body From Upload' disabled={this.state.dataset.url} csv json />
+            </div>
+          </div>
+          <div className={css('fileWrap')}>
+            <div className={css('fileText')}>I want to add a dataset file to fill out the structure, metadata, transformation, and/or commit details (optional):</div>
+            <DropFile name='file' onChange={this.handleChange} label='Add Dataset .yaml or .json file' yaml json />
+          </div>
           <div className={css('buttonWrap')}>
             <Button loading={loading} disabled={disabled} onClick={this.handleSubmit} text='Add Dataset' name='add-dataset' />
             <div className={css('message')}>{loading ? undefined : message }</div>
@@ -164,10 +181,37 @@ export default class AddDataset extends Base {
         margin: 'auto'
       },
       name: {
-        marginBottom: 60
+        marginTop: 40,
+        marginBottom: 60,
+        display: 'flex',
+        alignItems: 'baseline'
       },
       spinnerOffset: {
         marginLeft: 50
+      },
+      datasetNameText: {
+        display: 'inline-block',
+        marginRight: 10
+      },
+      bodyWrap: {
+        display: 'flex',
+        flexDirection: 'column'
+      },
+      bodyText: {
+        marginBottom: 20,
+        display: 'flex',
+        alignItems: 'baseline',
+        justifyContent: 'space-between'
+      },
+      block: {
+        display: 'block',
+        height: 225
+      },
+      none: {
+        display: 'none'
+      },
+      fileText: {
+        marginBottom: 20
       }
     }
   }

--- a/lib/components/Stylesheet.js
+++ b/lib/components/Stylesheet.js
@@ -17,7 +17,7 @@ import Button from './Button'
 import List from './List'
 import Dropdown from './Dropdown'
 import DropdownMenu from './DropdownMenu'
-import ValidCitationsInput from './form/ValidCitationsInput'
+import RadioInput from './form/RadioInput'
 
 export default class Stylesheet extends Base {
   constructor (props) {
@@ -159,7 +159,16 @@ export default class Stylesheet extends Base {
           <div className={css('button')} style={{ width: 200, float: 'left' }}><Dropdown text='dropdown' color='e' name='dropdown' dropdown={DropdownMenu} /></div>
         </div>
         <div style={{clear: 'both'}}>
-          <ValidCitationsInput />
+          <div><RadioInput name='test' value='a' text='radio a' color='a' /></div>
+          <div><RadioInput name='test' value='b' text='radio b' color='b' /></div>
+          <div><RadioInput name='test' value='c' text='radio c' color='c' /></div>
+          <div><RadioInput name='test' value='d' text='radio d' color='d' /></div>
+          <div><RadioInput name='test' value='e' text='radio e' color='e' /></div>
+          <div><RadioInput name='test' value='f' text='radio f' color='f' /></div>
+          <div><RadioInput name='test' value='neutral-bold' text='radio neutral-bold' color='neutral-bold' /></div>
+          <div><RadioInput name='test' value='neutral' text='radio neutral' color='neutral' /></div>
+          <div><RadioInput name='test' value='neutral-muted' text='radio neutral-muted' color='neutral-muted' /></div>
+          <div><RadioInput name='test' value='dark' text='radio dark' color='dark' /></div>
         </div>
         <div className={css('bottom')} />
       </div>

--- a/lib/components/form/DropFile.js
+++ b/lib/components/form/DropFile.js
@@ -201,7 +201,6 @@ export default class DropFile extends Base {
         height: '150px'
       },
       uploader: {
-        marginTop: '20px',
         marginBottom: '20px'
       },
       dropText: {

--- a/lib/components/form/DropFile.js
+++ b/lib/components/form/DropFile.js
@@ -246,10 +246,10 @@ export default class DropFile extends Base {
       },
       remove: {
         position: 'absolute',
-        top: '-8px',
+        top: '-7px',
         right: '-7px',
         cursor: 'pointer',
-        background: '#55595c',
+        background: palette.neutralMuted,
         borderRadius: '8px',
         paddingRight: '4px',
         paddingLeft: '4px',

--- a/lib/components/form/RadioInput.js
+++ b/lib/components/form/RadioInput.js
@@ -13,11 +13,6 @@ export default class RadioInput extends Base {
   }
   styles () {
     return {
-      span: {
-        // display: 'flex'
-        // alignItems: 'baseline'
-        // text
-      }
     }
   }
 }

--- a/lib/components/form/RadioInput.js
+++ b/lib/components/form/RadioInput.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import Base from '../Base'
+
+export default class RadioInput extends Base {
+  template (css) {
+    const {name, value, text, color} = this.props
+    const className = 'radio-' + color
+    return (
+      <span><input className={className} type='radio' name={name} value={value} />{text}</span>
+    )
+  }
+  styles () {
+    return {}
+  }
+}
+
+RadioInput.propTypes = {
+  name: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  text: PropTypes.string.isRequired,
+  color: PropTypes.string.isRequired
+}
+
+RadioInput.defaultProps = {
+  color: 'a'
+}

--- a/lib/components/form/RadioInput.js
+++ b/lib/components/form/RadioInput.js
@@ -5,14 +5,20 @@ import Base from '../Base'
 
 export default class RadioInput extends Base {
   template (css) {
-    const {name, value, text, color} = this.props
+    const {name, value, text, color, defaultChecked, onChange} = this.props
     const className = 'radio-' + color
     return (
-      <span><input className={className} type='radio' name={name} value={value} />{text}</span>
+      <span className={css('span')}><input className={className} type='radio' name={name} value={value} defaultChecked={defaultChecked} onChange={onChange} />{text}</span>
     )
   }
   styles () {
-    return {}
+    return {
+      span: {
+        // display: 'flex'
+        // alignItems: 'baseline'
+        // text
+      }
+    }
   }
 }
 
@@ -20,7 +26,9 @@ RadioInput.propTypes = {
   name: PropTypes.string.isRequired,
   value: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
-  color: PropTypes.string.isRequired
+  color: PropTypes.string.isRequired,
+  defaultChecked: PropTypes.bool,
+  onChange: PropTypes.func
 }
 
 RadioInput.defaultProps = {

--- a/lib/components/form/ValidInput.js
+++ b/lib/components/form/ValidInput.js
@@ -10,7 +10,7 @@ export default class ValidInput extends Base {
     const { label, name, type, value, placeholder, showError, error, helpText, showHelpText, onChange, className, inline } = this.props
     const margin = css('margin')
     return (
-      <div className={`${margin} validFormField form-group ${error && showError && 'has-error'} ${className} ${inline ? 'inline' : ''} `}>
+      <div className={`${margin} validFormField form-group ${error && showError && 'has-error'} ${className} ${inline ? css('inline') : ''} `}>
         <input
           id={name}
           name={name}

--- a/lib/middleware/api.js
+++ b/lib/middleware/api.js
@@ -6,21 +6,19 @@ export const API_ROOT = `${__BUILD__.API_URL}`
 
 // Fetches an API response and normalizes the result JSON according to schema.
 // This makes every API response have the same shape, regardless of how nested it was.
-function callApi (method, endpoint, schema, data, files = []) {
+function callApi (method, endpoint, schema, data, files = {}) {
   let fullUrl = (endpoint.indexOf(API_ROOT) === -1) ? API_ROOT + endpoint : endpoint
   let headers, body
 
   // if files is provided, let's submit via form data
-  if (files.length > 0) {
+  if (Object.keys(files).length !== 0 && files.constructor === Object) {
     let fd = new FormData()
 
-    if (files.length === 1) {
-      fd.append('file', files[0])
-    } else {
-      files.forEach((i, f) => {
-        fd.append(`file_${i}`, f)
-      })
-    }
+    Object.keys(files).forEach((key, i) => {
+      if (files[key] && files[key][0]) {
+        return fd.append(key, files[key][0])
+      }
+    })
 
     Object.keys(data).forEach((key, i) => {
       fd.append(key, data[key])

--- a/lib/scss/_forms.scss
+++ b/lib/scss/_forms.scss
@@ -374,6 +374,41 @@ select.form-control-lg {
 }
 
 
+//
+// Radio button Variants:
+//
+
+.radio-a {
+  @include radio-variant($a, $neutral)
+}
+.radio-b {
+  @include radio-variant($b, $neutral)
+}
+.radio-c {
+  @include radio-variant($c, $neutral)
+}
+.radio-d {
+  @include radio-variant($d, $neutral)
+}
+.radio-e {
+  @include radio-variant($e, $neutral)
+}
+.radio-f {
+  @include radio-variant($f, $neutral)
+}
+.radio-neutral-bold {
+  @include radio-variant($neutral-bold, $neutral)
+}
+.radio-neutral {
+  @include radio-variant($white, $neutral)
+}
+.radio-neutral-muted {
+  @include radio-variant($neutral-muted, $neutral)
+}
+.radio-dark {
+  @include radio-variant($a, $black)
+}
+
 // Help Hints
 //
 // Help Hints appear underneath an input and describe what is needed in that particular field

--- a/lib/scss/mixins/_forms.scss
+++ b/lib/scss/mixins/_forms.scss
@@ -83,3 +83,28 @@
     height: auto;
   }
 }
+
+// Radio variant
+// 
+// Used in _forms to create the different colors that the radio button can have
+@mixin radio-variant($checked-color, $background-color) {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+
+  border-radius: 50%;
+  width: 16px;
+  height: 16px;
+
+  border: 2px solid $background-color;
+  background: $background-color;
+  transition: 0.2s all linear;
+  outline: none;
+  margin-right: 5px;
+
+  position: relative;
+  top: 4px;
+  &:checked {
+    background: $checked-color;
+  }
+}

--- a/lib/scss/mixins/_forms.scss
+++ b/lib/scss/mixins/_forms.scss
@@ -100,10 +100,10 @@
   background: $background-color;
   transition: 0.2s all linear;
   outline: none;
-  margin-right: 5px;
+  margin-right: 10px;
 
   position: relative;
-  top: 4px;
+  top: 2px;
   &:checked {
     background: $checked-color;
   }


### PR DESCRIPTION
With the CLI, you can add a dataset using a dataset .yaml or .json file as well as from a body.csv file.

On the frontend, you could only add from a body.csv/.json file.

We have higher ambitions for the AddDataset component, but for now, you can now upload both a body and dataset file when you are adding a dataset to qri.