### PR TITLE
refactor(*): switch Meta and Body tabs, add style to Meta component, switch default dataset and viz views

### DIFF
--- a/lib/actions/dataset.js
+++ b/lib/actions/dataset.js
@@ -85,11 +85,12 @@ export function loadDatasets (id, page = 1, pageSize = 30) {
   }
 }
 
-export function fetchDatasetByPath (path) {
+export function fetchDatasetByPath (path, peername, name) {
+  const namedPath = peername && name ? `/${peername}/${name}/at${path}` : `/at${path}`
   return {
     [CALL_API]: {
       types: [DATASET_REQUEST, DATASET_SUCCESS, DATASET_FAILURE],
-      endpoint: `/at${path}`,
+      endpoint: namedPath,
       schema: Schemas.DATASET,
       path
     }
@@ -122,7 +123,7 @@ export function loadDatasetByName (peername, name, requiredFields = []) {
   }
 }
 
-export function loadDatasetByPath (path, requiredFields = []) {
+export function loadDatasetByPath (path, peername, name, requiredFields = []) {
   return (dispatch, getState) => {
     const datasetRef = selectDatasetByPath(getState(), path)
     // datasets are stored with their structure as a hash reference
@@ -133,7 +134,7 @@ export function loadDatasetByPath (path, requiredFields = []) {
     if (datasetRef && datasetRef.dataset && requiredFields.every(key => hasOwnNestedProperty(datasetRef.dataset, key))) {
       return null
     }
-    return dispatch(fetchDatasetByPath(path))
+    return dispatch(fetchDatasetByPath(path, peername, name))
   }
 }
 

--- a/lib/components/Dataset.js
+++ b/lib/components/Dataset.js
@@ -24,7 +24,6 @@ export default class Dataset extends Base {
     super(props)
     this.state = {
       tabIndex: 0,
-      expanded: undefined,
       transitionViewModes: false
     };
 
@@ -42,8 +41,7 @@ export default class Dataset extends Base {
       'renderStructure',
       'renderBody',
       'renderComingSoon',
-      'renderTabPanel',
-      'handleToggleExpand'
+      'renderTabPanel'
     ].forEach((m) => { this[m] = this[m].bind(this) })
   }
 
@@ -156,7 +154,7 @@ export default class Dataset extends Base {
     const { datasetRef, sessionProfileName, peername, isLatestDataset, peer } = this.props
     const { dataset } = datasetRef
     return (<div className={css('overflow')} ><Meta meta={dataset.meta} onClickEdit={(!peer &&
-       isLatestDataset && sessionProfileName === peername) ? this.handleEditMetadata() : undefined} /></div>)
+       isLatestDataset && sessionProfileName === peername) ? this.handleEditMetadata() : undefined} structure={dataset.structure} /></div>)
   }
 
   modal (name, data = {}) {
@@ -212,13 +210,6 @@ export default class Dataset extends Base {
     )
   }
 
-  handleToggleExpand (panel) {
-    if (this.state.expanded === panel) {
-      panel = undefined
-    }
-    this.setState({ expanded: panel })
-  }
-
   renderTabPanel (css) {
     const { datasetRef, peername, name, peer } = this.props
     const { path, dataset } = datasetRef
@@ -229,8 +220,8 @@ export default class Dataset extends Base {
           index={tabIndex}
           labels={['Meta', 'Body', 'Structure', 'Viz']}
           onSelectPanel={this.changeTabIndex}
-          onToggleExpand={this.handleToggleExpand.bind(this, 'tabPanel')}
           expanded={expanded === 'tabPanel'}
+          clearBackground
           components={[
             this.renderMeta(css),
             this.renderBody(css),
@@ -245,8 +236,8 @@ export default class Dataset extends Base {
         index={tabIndex}
         labels={['Meta', 'Body', 'Structure', 'Changes', 'Viz']}
         onSelectPanel={this.changeTabIndex}
-        onToggleExpand={this.handleToggleExpand.bind(this, 'tabPanel')}
         expanded={expanded === 'tabPanel'}
+        clearBackground
         components={[
           this.renderMeta(css),
           this.renderBody(css),
@@ -262,44 +253,42 @@ export default class Dataset extends Base {
     const { datasetRef, isLatestDataset, peername, peer, sessionProfileName } = this.props
 
     return (
-      <div className={css('dataset')}>
-        <div className={css('content')}>
-          <div className={css('topPanel')} >
-            <DatasetHeader
-              datasetRef={datasetRef}
-              // only allow dataset removal if !peer and is latest dataset
-              onClickDelete={!peer && isLatestDataset ? this.handleDeleteDataset() : undefined}
-              // only export if not peer
-              exportPath={!peer ? this.handleDownloadDataset() : undefined}
-              onGoBack={this.handleGoBack}
-              // only add if peer
-              onClickAdd={peer ? this.handleAddDataset() : undefined}
-              // onClickRename={this.handleShowRenameModal()}
-              // only rename if peername is sessionProfileName, not peer, and is latest dataset
-              onClickRename={(peername === sessionProfileName && !peer && isLatestDataset) ? this.handleShowRenameModal() : undefined}
-              peer={peer}
-              description={this.handleDescription()}
-              isLatestDataset={isLatestDataset}
-              sessionProfile={this.props.sessionProfile}
-            />
-          </div>
-          <div className={css('middlePanel')}>{this.renderTabPanel(css)}</div>
-          <div className={css('bottomPanel')}>
-            {/* <div className='col-md-7' >
+      <div className={css('content')}>
+        <div className={css('topPanel')} >
+          <DatasetHeader
+            datasetRef={datasetRef}
+            // only allow dataset removal if !peer and is latest dataset
+            onClickDelete={!peer && isLatestDataset ? this.handleDeleteDataset() : undefined}
+            // only export if not peer
+            exportPath={!peer ? this.handleDownloadDataset() : undefined}
+            onGoBack={this.handleGoBack}
+            // only add if peer
+            onClickAdd={peer ? this.handleAddDataset() : undefined}
+            // onClickRename={this.handleShowRenameModal()}
+            // only rename if peername is sessionProfileName, not peer, and is latest dataset
+            onClickRename={(peername === sessionProfileName && !peer && isLatestDataset) ? this.handleShowRenameModal() : undefined}
+            peer={peer}
+            description={this.handleDescription()}
+            isLatestDataset={isLatestDataset}
+            sessionProfile={this.props.sessionProfile}
+          />
+        </div>
+        <div className={css('middlePanel')}>{this.renderTabPanel(css)}</div>
+        {/* <div className={css('bottomPanel')}>
+            <div className='col-md-7' >
               <h5>Details</h5>
               <p>{this.handleDescription(dataset)}</p>
             </div>
             <div className='col-md-3'>
               <h5>Contributors</h5>
-            </div> */}
-          </div>
-        </div>
+            </div>
+          </div> */}
       </div>)
   }
 
   template (css) {
     const { datasetRef, peername, name, viewMode } = this.props
-    const { expanded, transitionViewModes } = this.state
+    const { transitionViewModes } = this.state
     // const path = "/" + address.replace(".", "/", -1)
     // const hasData = (dataset && (dataset.url || dataset.file || dataset.data));
     // TODO hasData is assigned a value but never used, consider depreciation
@@ -312,85 +301,75 @@ export default class Dataset extends Base {
       return (<Spinner />)
     }
 
-    switch (expanded) {
-      case 'tabPanel':
-        return (
-          <div className={css('tabPanelWrap')}>
-            <div className={css('expanded')}>
-              {this.renderTabPanel(css)}
-            </div>
-          </div>
-        )
-      default:
-        return (
-          <div className={css('wrap')} >
-            {(viewMode === 'viz' || transitionViewModes) &&
-              <div style={{
-                position: 'absolute',
-                width: '100%',
-                height: '100%',
-                overflow: 'hidden',
-                transition: 'left 0.5s',
-                left: (viewMode === 'viz') ? 0 : '100%',
-                background: defaultPalette.background,
-                boxShadow: '0 0 16px rba(0,0,0,0.75)'
-              }}>
-                {this.renderViz(peername, name)}
-              </div>
-            }
-            {(viewMode === 'dataset' || transitionViewModes) && this.renderDataset(css)}
-          </div>
-        )
-    }
+    return (
+      <div className={css('wrap')} >
+        {(viewMode === 'viz' || transitionViewModes) &&
+        <div style={{
+          position: 'absolute',
+          width: '100%',
+          height: '100%',
+          overflow: 'hidden',
+          transition: 'left 0.5s',
+          left: (viewMode === 'viz') ? 0 : '100%',
+          background: defaultPalette.background,
+          boxShadow: '0 0 16px rba(0,0,0,0.75)'
+        }}>
+          {this.renderViz(peername, name)}
+        </div>
+        }
+        {(viewMode === 'dataset' || transitionViewModes) && this.renderDataset(css)}
+      </div>
+    )
   }
 
   styles () {
+    const palette = defaultPalette
+
     return {
       wrap: {
         height: '100%',
         display: 'flex',
         flexFlow: 'column',
-        alignItems: 'stretch'
+        alignItems: 'stretch',
+        overflowY: 'scroll'
       },
       content: {
         margin: '0 auto',
-        maxWidth: 960
-      },
-      dataset: {
+        maxWidth: 960,
         paddingLeft: 20,
-        paddingRight: 20
+        paddingRight: 20,
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%'
       },
       overflow: {
         width: '100%',
-        paddingLeft: 10,
-        paddingBottom: 10
+        padding: 30
       },
       topPanel: {
-        flex: 'auto',
+        flex: '0 0 125px',
         width: '100%'
       },
       middlePanel: {
-        flex: '1 1 500px',
-        width: '100%'
+        flex: '5 1 500px',
+        width: '100%',
+        marginTop: 20,
+        background: palette.sink
       },
-      bottomPanel: {
-        flex: 'auto',
-        marginTop: 40,
-        minHeight: 100,
-        width: '100%'
-      },
+      // bottomPanel: {
+      //   flex: 'auto',
+      //   marginTop: 40,
+      //   minHeight: 100,
+      //   width: '100%'
+      // },
       comingSoonWrap: {
         margin: 20
       },
       tabPanelWrap: {
         padding: '40px 20px 20px 20px',
-        height: '100%',
         display: 'flex',
         flexFlow: 'column',
         alignItems: 'stretch'
-      },
-      expanded: {
-        flex: '2 1 100%'
       },
       width: {
         width: '100%'

--- a/lib/components/Dataset.js
+++ b/lib/components/Dataset.js
@@ -357,7 +357,7 @@ export default class Dataset extends Base {
       },
       content: {
         margin: '0 auto',
-        maxWidth: 960,
+        width: 960,
         paddingLeft: 20,
         paddingRight: 20,
         display: 'flex',

--- a/lib/components/Dataset.js
+++ b/lib/components/Dataset.js
@@ -227,14 +227,14 @@ export default class Dataset extends Base {
       return (
         <TabPanel
           index={tabIndex}
-          labels={['Body', 'Structure', 'Meta', 'Viz']}
+          labels={['Meta', 'Body', 'Structure', 'Viz']}
           onSelectPanel={this.changeTabIndex}
           onToggleExpand={this.handleToggleExpand.bind(this, 'tabPanel')}
           expanded={expanded === 'tabPanel'}
           components={[
+            this.renderMeta(css),
             this.renderBody(css),
             this.renderStructure(css, dataset),
-            this.renderMeta(css),
             this.renderViz(peername, name)
           ]}
         />
@@ -243,14 +243,14 @@ export default class Dataset extends Base {
     return (
       <TabPanel
         index={tabIndex}
-        labels={['Body', 'Structure', 'Meta', 'Changes', 'Viz']}
+        labels={['Meta', 'Body', 'Structure', 'Changes', 'Viz']}
         onSelectPanel={this.changeTabIndex}
         onToggleExpand={this.handleToggleExpand.bind(this, 'tabPanel')}
         expanded={expanded === 'tabPanel'}
         components={[
+          this.renderMeta(css),
           this.renderBody(css),
           this.renderStructure(css, dataset),
-          this.renderMeta(css),
           this.renderChanges(peername, name, path),
           this.renderViz(peername, name)
         ]}

--- a/lib/components/Dataset.js
+++ b/lib/components/Dataset.js
@@ -21,6 +21,7 @@ const RENAME_DATASET_MODAL = 'RENAME_DATASET_MODAL'
 
 // DATASET_DEBUG = 1 will print the if statements and functions run in componentWillMount and componentWillRecieveProps
 // DATASET_DEBUG = 2 will print the above and also the props, or the props and nextProps, in the componentWillMount and componentWillRecieveProps
+// DATASET_DEBUG >= 0 will remove any logging
 const DATASET_DEBUG = -1
 
 export default class Dataset extends Base {
@@ -62,7 +63,7 @@ export default class Dataset extends Base {
       this.props.loadDatasetByName(peername, name)
     } else if (!datasetRef || !bodypath || !schema) {
       if (DATASET_DEBUG >= 1) { console.log('!datasetRef || !bodypath || !schema: \nabout to loadDatasetByPath') }
-      this.props.loadDatasetByPath(path, ['bodypath', 'structure.schema'])
+      this.props.loadDatasetByPath(path, peername, name, ['bodypath', 'structure.schema'])
     } else if (sessionProfile && !body) {
       if (DATASET_DEBUG >= 1) { console.log('sessionProfile && !body: \nabout to loadDatasetBody') }
       this.props.loadDatasetBody(path, bodypath)
@@ -72,10 +73,6 @@ export default class Dataset extends Base {
   componentWillReceiveProps (nextProps) {
     if (DATASET_DEBUG >= 1) { console.log('componentWillReceiveProps') }
     if (DATASET_DEBUG >= 2) {
-      console.log('this.props:')
-      console.log(this.props)
-      console.log('nextProps')
-      console.log(nextProps)
     }
     const { peername, name, sessionProfile, bodypath, viewMode } = this.props
     if (!nextProps.path || peername !== nextProps.peername || name !== nextProps.name) {
@@ -84,7 +81,7 @@ export default class Dataset extends Base {
     } else if (!nextProps.datasetRef || !nextProps.bodypath || !nextProps.schema) {
       if (DATASET_DEBUG >= 1) { console.log('!nextProps.datasetRef || !nextProps.bodypath || !nextProps.schema: \nabout to loadDatasetByPath') }
       this.props.loadDatasetByPath(nextProps.path, ['bodypath', 'structure.schema'])
-    } else if (sessionProfile && bodypath !== nextProps.bodypath || (!nextProps.body && !nextProps.loading)) {
+    } else if (sessionProfile && (bodypath !== nextProps.bodypath || (!nextProps.body && !nextProps.loading))) {
       if (DATASET_DEBUG >= 1) { console.log('sessionProfile && nextProps.bodypath !== bodypath: \nabout to loadDatasetBody') }
       this.props.loadDatasetBody(nextProps.path, nextProps.bodypath)
     }
@@ -273,7 +270,7 @@ export default class Dataset extends Base {
   }
 
   renderDataset (css) {
-    const { datasetRef, isLatestDataset, peername, peer, sessionProfileName } = this.props
+    const { datasetRef, isLatestDataset, peername, peer, sessionProfileName, name } = this.props
 
     return (
       <div className={css('content')}>
@@ -294,6 +291,8 @@ export default class Dataset extends Base {
             description={this.handleDescription()}
             isLatestDataset={isLatestDataset}
             sessionProfile={this.props.sessionProfile}
+            peername={peername}
+            name={name}
           />
         </div>
         <div className={css('middlePanel')}>{this.renderTabPanel(css)}</div>
@@ -311,8 +310,6 @@ export default class Dataset extends Base {
 
   template (css) {
     const { datasetRef, peername, name, viewMode } = this.props
-    console.log(peername)
-    console.log(name)
     const { transitionViewModes } = this.state
     // const path = "/" + address.replace(".", "/", -1)
     // const hasData = (dataset && (dataset.url || dataset.file || dataset.data));

--- a/lib/components/Dataset.js
+++ b/lib/components/Dataset.js
@@ -19,6 +19,10 @@ import Spinner from './Spinner'
 
 const RENAME_DATASET_MODAL = 'RENAME_DATASET_MODAL'
 
+// DATASET_DEBUG = 1 will print the if statements and functions run in componentWillMount and componentWillRecieveProps
+// DATASET_DEBUG = 2 will print the above and also the props, or the props and nextProps, in the componentWillMount and componentWillRecieveProps
+const DATASET_DEBUG = -1
+
 export default class Dataset extends Base {
   constructor (props) {
     super(props)
@@ -46,23 +50,42 @@ export default class Dataset extends Base {
   }
 
   componentWillMount () {
+    if (DATASET_DEBUG >= 1) { console.log('componentWillMount') }
+    if (DATASET_DEBUG >= 2) {
+      console.log('this.props:')
+      console.log(this.props)
+    }
+
     const { peername, name, datasetRef, path, body, bodypath, sessionProfile, schema } = this.props
     if (!path) {
+      if (DATASET_DEBUG >= 1) { console.log('!path: \nabout to loadDatasetByName') }
       this.props.loadDatasetByName(peername, name)
     } else if (!datasetRef || !bodypath || !schema) {
+      if (DATASET_DEBUG >= 1) { console.log('!datasetRef || !bodypath || !schema: \nabout to loadDatasetByPath') }
       this.props.loadDatasetByPath(path, ['bodypath', 'structure.schema'])
     } else if (sessionProfile && !body) {
+      if (DATASET_DEBUG >= 1) { console.log('sessionProfile && !body: \nabout to loadDatasetBody') }
       this.props.loadDatasetBody(path, bodypath)
     }
   }
 
   componentWillReceiveProps (nextProps) {
+    if (DATASET_DEBUG >= 1) { console.log('componentWillReceiveProps') }
+    if (DATASET_DEBUG >= 2) {
+      console.log('this.props:')
+      console.log(this.props)
+      console.log('nextProps')
+      console.log(nextProps)
+    }
     const { peername, name, sessionProfile, bodypath, viewMode } = this.props
     if (!nextProps.path || peername !== nextProps.peername || name !== nextProps.name) {
+      if (DATASET_DEBUG >= 1) { console.log('!nextProps.path || peername !== nextProps.peername || name !== nextProps.name: \n about to loadDatasetByName') }
       this.props.loadDatasetByName(nextProps.peername, nextProps.name)
     } else if (!nextProps.datasetRef || !nextProps.bodypath || !nextProps.schema) {
+      if (DATASET_DEBUG >= 1) { console.log('!nextProps.datasetRef || !nextProps.bodypath || !nextProps.schema: \nabout to loadDatasetByPath') }
       this.props.loadDatasetByPath(nextProps.path, ['bodypath', 'structure.schema'])
-    } else if (sessionProfile && nextProps.bodypath !== bodypath) {
+    } else if (sessionProfile && bodypath !== nextProps.bodypath || (!nextProps.body && !nextProps.loading)) {
+      if (DATASET_DEBUG >= 1) { console.log('sessionProfile && nextProps.bodypath !== bodypath: \nabout to loadDatasetBody') }
       this.props.loadDatasetBody(nextProps.path, nextProps.bodypath)
     }
 
@@ -288,6 +311,8 @@ export default class Dataset extends Base {
 
   template (css) {
     const { datasetRef, peername, name, viewMode } = this.props
+    console.log(peername)
+    console.log(name)
     const { transitionViewModes } = this.state
     // const path = "/" + address.replace(".", "/", -1)
     // const hasData = (dataset && (dataset.url || dataset.file || dataset.data));

--- a/lib/components/DatasetHeader.js
+++ b/lib/components/DatasetHeader.js
@@ -95,7 +95,7 @@ export default class DatasetHeader extends Base {
       },
       buttons: {
         display: 'flex',
-        alignItems: 'center',
+        alignItems: 'flex-start',
         justifyContent: 'flex-end',
         margin: '10px 0 10px 0',
         width: 220

--- a/lib/components/DatasetHeader.js
+++ b/lib/components/DatasetHeader.js
@@ -2,10 +2,11 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import DatasetRefProps from '../propTypes/datasetRefProps'
-import DatasetItem from './item/DatasetItem'
 import PageHeader from './PageHeader'
 import ReadOnlyHeader from './ReadOnlyHeader'
 import Button from './Button'
+import DatasetName from './DatasetName'
+import Hash from './Hash'
 
 import { defaultPalette } from '../propTypes/palette'
 import Base from './Base'
@@ -17,7 +18,6 @@ export default class DatasetHeader extends Base {
       readMore: true
     };
     [
-      'renderDescription',
       'handleReadMore',
       'renderHeader'
     ].forEach((m) => { this[m] = this[m].bind(this) })
@@ -25,22 +25,6 @@ export default class DatasetHeader extends Base {
 
   handleReadMore (e) {
     this.setState({readMore: !this.state.readMore})
-  }
-
-  renderDescription (css) {
-    const { datasetRef } = this.props
-    if (!(datasetRef.dataset && datasetRef.dataset.meta && datasetRef.dataset.meta.description)) {
-      return
-    }
-    const description = datasetRef.dataset.meta.description
-
-    if (description.length < 90) {
-      return (<p>{description}</p>)
-    } else if (this.state.readMore) {
-      return (<p>{description.slice(0, 90)}... <span className={`${css('linkText')} ${css('link')}`} onClick={this.handleReadMore}><small>(read more)</small></span></p>)
-    } else {
-      return (<p>{description}<span className={`${css('linkText')} ${css('link')}`} onClick={this.handleReadMore}> <small>(read less)</small></span></p>)
-    }
   }
 
   renderHeader () {
@@ -60,13 +44,16 @@ export default class DatasetHeader extends Base {
   }
 
   template (css) {
-    const { datasetRef, peer, isLatestDataset, onClickRename, onClickDelete, onClickAdd, exportPath } = this.props
+    const { datasetRef, isLatestDataset, onClickRename, onClickDelete, onClickAdd, exportPath } = this.props
     return (
       <div className='dataSetHeader'>
         <div className={css('flex')}>
           <div className={css('datasetItem')}>
-            <DatasetItem rename={peer ? undefined : onClickRename} data={datasetRef} link={false} peer={peer} isLatestDataset={isLatestDataset} />
-            {this.renderDescription(css)}
+            {!isLatestDataset ? <div className={css('previousCommit')}>You are viewing a previous version of this dataset</div> : undefined}
+            <div className='displayInlineBlock'>
+              <DatasetName rename={onClickRename} peername={datasetRef.peername} name={datasetRef.name || 'unnamed dataset'} xlarge style={{display: 'inline-block', marginTop: 15}} />
+              <Hash hash={datasetRef.path} style={{marginBottom: 15}} />
+            </div>
           </div>
           <div className={css('buttons')}>
             { onClickDelete ? <span className={css('button')}><Button text='Remove' onClick={onClickDelete} color='d' name='remove' /></span> : undefined }
@@ -103,7 +90,8 @@ export default class DatasetHeader extends Base {
       flex: {
         display: 'flex',
         justifyContent: 'space-between',
-        flexWrap: 'wrap'
+        flexWrap: 'wrap',
+        margin: '30px 0 0 0'
       },
       buttons: {
         display: 'flex',

--- a/lib/components/DatasetHeader.js
+++ b/lib/components/DatasetHeader.js
@@ -44,14 +44,14 @@ export default class DatasetHeader extends Base {
   }
 
   template (css) {
-    const { datasetRef, isLatestDataset, onClickRename, onClickDelete, onClickAdd, exportPath } = this.props
+    const { datasetRef, isLatestDataset, onClickRename, onClickDelete, onClickAdd, exportPath, peername, name } = this.props
     return (
       <div className='dataSetHeader'>
         <div className={css('flex')}>
           <div className={css('datasetItem')}>
             {!isLatestDataset ? <div className={css('previousCommit')}>You are viewing a previous version of this dataset</div> : undefined}
             <div className='displayInlineBlock'>
-              <DatasetName rename={onClickRename} peername={datasetRef.peername} name={datasetRef.name || 'unnamed dataset'} xlarge style={{display: 'inline-block', marginTop: 15}} />
+              <DatasetName rename={onClickRename} peername={peername} name={name || 'unnamed dataset'} xlarge style={{display: 'inline-block', marginTop: 15}} />
               <Hash hash={datasetRef.path} style={{marginBottom: 15}} />
             </div>
           </div>
@@ -119,7 +119,9 @@ DatasetHeader.propTypes = {
   onClickDelete: PropTypes.func,
   onClickAdd: PropTypes.func,
   peer: PropTypes.bool,
-  sessionProfile: PropTypes.string
+  sessionProfile: PropTypes.string,
+  peername: PropTypes.string,
+  name: PropTypes.string
 }
 
 DatasetHeader.defaultProps = {

--- a/lib/components/DatasetName.js
+++ b/lib/components/DatasetName.js
@@ -7,11 +7,11 @@ import Base from './Base'
 
 export default class DatasetName extends Base {
   template (css) {
-    const { peername, name, large, style, save, rename } = this.props
+    const { peername, name, large, style, save, rename, xlarge } = this.props
     const datasetLarge = large ? 'large' : undefined
     const datasetName = save ? 'save' : 'datasetName'
     return (
-      <div className={`datasetName ${datasetLarge} ${css(datasetName)}`} style={style}>
+      <div className={`datasetName ${datasetLarge} ${xlarge ? css('xlarge') : undefined} ${css(datasetName)}`} style={style}>
         {peername ? `${peername}/${name}` : name}
         { rename ? <span title='edit dataset name' className={`icon-inline ${css('edit')}`} onClick={() => rename()}>pen</span> : undefined}
       </div>
@@ -37,6 +37,9 @@ export default class DatasetName extends Base {
         ':hover': {
           color: palette.d
         }
+      },
+      xlarge: {
+        fontSize: 30
       }
     }
   }

--- a/lib/components/MetadataEditor.js
+++ b/lib/components/MetadataEditor.js
@@ -35,9 +35,9 @@ export default class MetadataEditor extends Base {
   }
 
   componentWillMount () {
-    const { path, localDatasetRef, datasetRef } = this.props
+    const { path, localDatasetRef, datasetRef, peername, name } = this.props
     if (!datasetRef) {
-      this.props.loadDatasetByPath(path)
+      this.props.loadDatasetByPath(path, peername, name)
     }
     if (!localDatasetRef && datasetRef) {
       this.props.newDataset(datasetRef)

--- a/lib/components/TabPanel.js
+++ b/lib/components/TabPanel.js
@@ -54,15 +54,15 @@ export default class TabPanel extends Base {
             return (
               <a
                 key={i}
-                className={css('tab', i === panel && 'currentTab')}
-                onClick={this.handleSetPanel.bind(this, i, onSelectPanel)}><h4>{label}</h4></a>
+                className={css('tab')}
+                onClick={this.handleSetPanel.bind(this, i, onSelectPanel)}><h4 className={css('tabh4', i === panel && 'currentTab')}>{label}</h4></a>
             )
           }
           )}
         </div>
 
         {search ? this.renderSearch(css) : undefined}
-        <div className={css('content')}>
+        <div className={`${css('content')} ${clearBackground ? css('contentSink') : ''}`}>
           {component}
         </div>
       </div>
@@ -73,15 +73,15 @@ export default class TabPanel extends Base {
     const palette = defaultPalette
     return {
       background: {
-        background: palette.sink
+        background: palette.sink,
+        padding: 15
       },
       wrap: {
         height: '100%',
         overflow: 'hidden',
         borderRadius: 3,
         display: 'flex',
-        flexFlow: 'column nowrap',
-        padding: 15
+        flexFlow: 'column nowrap'
       },
       search: {
         height: 45,
@@ -89,7 +89,6 @@ export default class TabPanel extends Base {
       },
       tab: {
         display: 'inline-block',
-        color: palette.neutral,
         transition: 'all 0.25s',
         marginRight: 40
       },
@@ -105,11 +104,12 @@ export default class TabPanel extends Base {
         color: palette.a
       },
       header: {
-        fontWeight: 'bold'
+        fontWeight: 'bold',
+        background: palette.background
       },
       content: {
-        flex: '2 1 90%',
-        display: 'flex'
+        display: 'flex',
+        height: '100%'
       }
     }
   }

--- a/lib/components/TagList.js
+++ b/lib/components/TagList.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import Base from './Base'
+import TagItem from './item/TagItem'
+
+export default class TagList extends Base {
+  template (css) {
+    const { tags } = this.props
+
+    return (
+      <div className={css('wrap')}>
+        {tags.map(tag => <TagItem tag={tag} />)}
+      </div>
+    )
+  }
+
+  styles () {
+    return {
+      wrap: {
+        margin: '10px 0'
+      }
+    }
+  }
+}
+
+TagList.propTypes = {
+  tags: PropTypes.array
+  // add in when we move styling to scss
+  // color: PropTypes.string
+}
+
+TagList.defaultProps = {
+  // color: 'a'
+}

--- a/lib/components/item/DatasetItem.js
+++ b/lib/components/item/DatasetItem.js
@@ -10,14 +10,10 @@ import Base from '../Base'
 
 export default class DatasetItem extends Base {
   constructor (props) {
-    super(props)
-    this.state = {
-      saveButtonState: 'displayNone'
-    };
+    super(props);
     [
       'handleOnMouseEnter',
       'handleOnMouseLeave',
-      'renderSave',
       'renderOnAdd',
       'titleString'
     ].forEach((m) => { this[m] = this[m].bind(this) })
@@ -69,7 +65,7 @@ export default class DatasetItem extends Base {
 
   titleString () {
     const {data = {}, small} = this.props
-    const name = data.name || ""
+    const name = data.name || ''
     const {dataset = {}} = data
     const { meta = {} } = dataset
     if (small && meta && meta.title && meta.title.length > 30) {
@@ -102,15 +98,6 @@ export default class DatasetItem extends Base {
     this.props.onAdd(this.props.data)
   }
 
-  renderSave (css) {
-    const { saveButtonState } = this.state
-    return (
-      <div className={`${css('save')} ${css(saveButtonState)}`} onClick={this.renderOnAdd} >
-        <DatasetName save name='Save' />
-      </div>
-    )
-  }
-
   template (css) {
     const { data, link, small, isLatestDataset, rename } = this.props
     const title = this.titleString()
@@ -125,7 +112,6 @@ export default class DatasetItem extends Base {
               <span className={css('name')}>{`${data.peername}/${data.name}` || <i>unnamed dataset</i>}</span>
               <h3 className={css('title')}>{title || <i>untitled dataset</i>}</h3>
             </Link>
-            { data.peer ? this.renderSave(css) : undefined}
             { data.dataset && data.dataset.structure ? <StatsLine muted stats={this.stats(data)} /> : undefined}
           </div>
         </div>
@@ -136,7 +122,6 @@ export default class DatasetItem extends Base {
           {!isLatestDataset ? <div className={css('previousCommit')}>You are viewing a previous version of this dataset</div> : undefined}
           <div className='displayInlineBlock'>
             <DatasetName rename={rename} peername={data.peername} name={data.name || 'unnamed dataset'} large style={{display: 'inline-block', marginTop: 15}} />
-            { data.peer ? this.renderSave(css) : undefined}
             <h2>{title || 'untitled dataset'}</h2>
             <Hash hash={data.path} style={{marginBottom: 15}} />
             <StatsLine stats={this.stats(data)} extraSpace large style={{marginTop: 30}} />
@@ -169,13 +154,6 @@ export default class DatasetItem extends Base {
       muted: {
         marginTop: 4,
         color: palette.neutralBold
-      },
-      save: {
-        marginLeft: 30,
-        cursor: 'pointer'
-      },
-      displayNone: {
-        display: 'none'
       },
       displayInlineBlock: {
         display: 'inline-block'

--- a/lib/components/item/TagItem.js
+++ b/lib/components/item/TagItem.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { defaultPalette } from '../../propTypes/palette'
+
+import Base from '../Base'
+
+export default class TagItem extends Base {
+  template (css) {
+    const { tag } = this.props
+
+    return (<div className={css('pill')}>#{tag}</div>)
+  }
+
+  styles () {
+    // want to move tag styling to scss, but for now:
+    const palette = defaultPalette
+    return {
+      pill: {
+        // border: '1px solid' + palette.a,
+        borderRadius: 15,
+        color: palette.neutral,
+        margin: '5px 5px 5px 0',
+        padding: '2px 20px 2px 0',
+        display: 'inline-block'
+      }
+    }
+  }
+}
+
+TagItem.propTypes = {
+  tag: PropTypes.string
+  // add in when we move styling to scss
+  // color: PropTypes.string
+}
+
+TagItem.defaultProps = {
+  // color: 'a'
+}

--- a/lib/components/meta.js
+++ b/lib/components/meta.js
@@ -2,12 +2,108 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import MetaProps from '../propTypes/metaProps.js'
 import Base from './Base'
-import Json from './Json'
 import Button from './Button'
+import TagList from './TagList'
+import StatsLine from './StatsLine'
+
+import { defaultPalette } from '../propTypes/palette'
 
 export default class Meta extends Base {
+  constructor (props) {
+    super(props);
+    [
+      'filterFields'
+      // 'renderFields'
+    ].forEach((m) => { this[m] = this[m].bind(this) })
+  }
+
+  filterFields (meta) {
+    const filter = [
+      'title',
+      'keywords',
+      'description',
+      'downloadPath',
+      'qri'
+    ]
+
+    return Object.keys(meta)
+      .filter(key => !filter.includes(key) && (meta[key].constructor === Object && Object.keys(meta[key]).length === 0))
+      .reduce((res, key) => Object.assign(res, { [key]: meta[key] }), {})
+  }
+
+  datasetLength (l) {
+    var length = {name: '', value: 0}
+    if (l > Math.pow(2, 80)) {
+      length.name = 'YB'
+      length.value = Math.trunc(l / Math.pow(2, 80))
+    } else if (l > Math.pow(2, 70)) {
+      length.name = 'ZB'
+      length.value = Math.trunc(l / Math.pow(2, 70))
+    } else if (l > Math.pow(2, 60)) {
+      length.name = 'EB'
+      length.value = Math.trunc(l / Math.pow(2, 60))
+    } else if (l > Math.pow(2, 50)) {
+      length.name = 'PB'
+      length.value = Math.trunc(l / Math.pow(2, 50))
+    } else if (l > Math.pow(2, 40)) {
+      length.name = 'TB'
+      length.value = Math.trunc(l / Math.pow(2, 40))
+    } else if (l > Math.pow(2, 30)) {
+      length.name = 'GB'
+      length.value = Math.trunc(l / Math.pow(2, 30))
+    } else if (l > Math.pow(2, 20)) {
+      length.name = 'MB'
+      length.value = Math.trunc(l / Math.pow(2, 20))
+    } else if (l > Math.pow(2, 10)) {
+      length.name = 'KB'
+      length.value = Math.trunc(l / Math.pow(2, 10))
+    } else if (l > 0) {
+      length.name = 'byte'
+      length.value = l
+    }
+    if (l !== 1) {
+      length.name += 's'
+    }
+    return length
+  }
+
+  stats (structure) {
+    const length = structure.length
+    const entries = structure.entries || 0
+    const errors = structure.errCount || 0
+
+    return [
+      {
+        name: (errors === 1) ? 'error' : 'errors',
+        value: errors
+      },
+      {
+        name: (entries === 1) ? 'entry' : 'entries',
+        value: entries
+      },
+      this.datasetLength(length)
+    ]
+  }
+
+  renderFields (meta, css) {
+    const filteredMeta = this.filterFields(meta)
+    return Object.keys(filteredMeta)
+      .map((key, i) => {
+        return (
+          <p key={i} className={css('fields')}>
+            <span className={css('key')}>
+              {JSON.stringify(key)}:
+            </span>
+            <span className={css('value')}>
+              {meta[key]}
+            </span>
+          </p>
+        )
+      })
+  }
+
   template (css) {
-    const { meta, onClickEdit } = this.props
+    const { meta, onClickEdit, structure } = this.props
 
     let md = meta
     if (typeof meta === 'string') {
@@ -15,18 +111,38 @@ export default class Meta extends Base {
     }
     return (
       <div className={css('flex')}>
-        {md ? <Json body={md} /> : <p>This dataset currently has no specified metadata</p>}
+        <div className={css('meta')} >
+          {md.title ? <h3>{md.title}</h3> : undefined}
+          {md.keywords ? <TagList tags={md.keywords} /> : undefined}
+          {md.description ? <p>{md.description}</p> : undefined}
+          {md.downloadPath ? <a>{md.downloadPath}</a> : undefined}
+          {structure ? <StatsLine muted stats={this.stats(structure)} /> : undefined}
+          {this.renderFields(md, css)}
+        </div>
         {onClickEdit ? <Button color='e' text='Edit' name='Edit' onClick={onClickEdit} /> : undefined}
       </div>
     )
   }
 
   styles () {
+    const palette = defaultPalette
     return {
       flex: {
-        marginRight: 10,
         display: 'flex',
         justifyContent: 'space-between'
+      },
+      fields: {
+        fontSize: 14,
+        marginTop: 20
+      },
+      value: {
+        marginLeft: 5
+      },
+      key: {
+        color: palette.neutral
+      },
+      meta: {
+        marginRight: 20
       }
     }
   }

--- a/lib/components/meta.js
+++ b/lib/components/meta.js
@@ -12,8 +12,8 @@ export default class Meta extends Base {
   constructor (props) {
     super(props);
     [
-      'filterFields'
-      // 'renderFields'
+      'filterFields',
+      'renderFields'
     ].forEach((m) => { this[m] = this[m].bind(this) })
   }
 
@@ -27,7 +27,7 @@ export default class Meta extends Base {
     ]
 
     return Object.keys(meta)
-      .filter(key => !filter.includes(key) && (meta[key].constructor === Object && Object.keys(meta[key]).length === 0))
+      .filter(key => !filter.includes(key) && !(meta[key].constructor === Object && Object.keys(meta[key]).length === 0))
       .reduce((res, key) => Object.assign(res, { [key]: meta[key] }), {})
   }
 

--- a/lib/components/meta.js
+++ b/lib/components/meta.js
@@ -105,6 +105,10 @@ export default class Meta extends Base {
   template (css) {
     const { meta, onClickEdit, structure } = this.props
 
+    if (meta === undefined) {
+      return (<p>No meta found for this dataset.</p>)
+    }
+
     let md = meta
     if (typeof meta === 'string') {
       md = {path: meta}

--- a/lib/containers/MetadataEditor.js
+++ b/lib/containers/MetadataEditor.js
@@ -15,6 +15,8 @@ const MetadataEditorContainer = connect(
     const path = `/${params.network}/${params.hash}`
     return Object.assign({
       path,
+      peername: params.peername,
+      name: params.name,
       sessionProfile: selectSessionProfileId(state),
       datasetRef: selectDatasetByPath(state, path),
       localDatasetRef: selectLocalDatasetByPath(state, path),

--- a/lib/reducers/__tests__/app.test.js
+++ b/lib/reducers/__tests__/app.test.js
@@ -23,7 +23,7 @@ describe('App Reducer', () => {
     modal: undefined,
     search: '',
     message: '',
-    viewMode: 'viz'
+    viewMode: 'dataset'
   }
 
   const state = {

--- a/lib/reducers/app.js
+++ b/lib/reducers/app.js
@@ -19,7 +19,7 @@ const initialState = {
   modal: undefined,
   search: '',
   message: '',
-  viewMode: 'viz'
+  viewMode: 'dataset'
 }
 
 export default function appReducer (state = initialState, action) {

--- a/lib/scss/_buttons.scss
+++ b/lib/scss/_buttons.scss
@@ -14,7 +14,7 @@
   cursor: pointer;
   user-select: none;
   border: $input-btn-border-width solid transparent;
-  @include button-size($btn-padding-y, $btn-padding-x, $font-size-base, $btn-border-radius);
+  @include button-size($btn-padding-y, $btn-padding-x, $btn-font-size, $btn-border-radius);
   @include transition(all .2s ease-in-out);
   min-width: $btn-min-width;
   height: $btn-height;

--- a/lib/scss/_variables.scss
+++ b/lib/scss/_variables.scss
@@ -281,7 +281,9 @@ $table-border-color:            $neutral !default;
 
 $btn-padding-x:                  1rem !default;
 $btn-padding-y:                  .5rem !default;
-$btn-line-height:                1.45 !default;
+$btn-line-height:                .9rem !default;
+$btn-font-size:                  $font-size-base * .75;
+
 $btn-font-weight:                bold !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba(255,255,255,.15), 0 1px 1px rgba(0,0,0,.075) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba(0,0,0,.125) !default;
@@ -328,8 +330,8 @@ $btn-dark-border:           darken(#000000, 15%) !default;
 
 $btn-link-disabled-color:        $neutral-muted !default;
 
-$btn-min-width:                  100px !default;
-$btn-height:                     40px !default;
+$btn-min-width:                  80px !default;
+$btn-height:                     30px !default;
 
 $btn-padding-x-sm:               .5rem !default;
 $btn-padding-y-sm:               .25rem !default;


### PR DESCRIPTION
* flips the body and meta tabs on the Dataset tabpanel
* changes dataset to show by default, rather than the viz
* Adds a `TagList` and `TagItem` component, for showing tags on the Meta display
* Adds a better-styled Meta component
* Changes the Dataset header to coincide with this new Meta display
* Adjust styling of the whole Dataset/TabPanel display
* Shrinks buttons
* Fixes bug that would skip `loadBody` on peer's dataset pages
* Fixes bug that would not show peername and dataset name when refreshing a peer's dataset page
* There is some weird behavior on the Dataset page, since the different tab panels have different natural widths, clicking through the different tabs cause weird sizing changes. To skirt that problem for the moment, we now have a set width for the Dataset page content