### PR TITLE
refactor(publish): correct logic on when to display publish/unpublish

### DIFF
--- a/lib/actions/dataset.js
+++ b/lib/actions/dataset.js
@@ -7,6 +7,7 @@ import { GET_CAF } from '../middleware/caf'
 import Schemas from '../schemas'
 import { selectDatasetByPath, selectDatasetByName } from '../selectors/dataset'
 import { selectSessionProfileId } from '../selectors/session'
+import { loadRegistryDatasets } from './registry'
 import { setMessage, resetMessage, clearPagination } from './app'
 import { setTransferStatus, removeTransferStatus } from './transfers'
 import { makeRef } from '../utils/ref'
@@ -366,6 +367,16 @@ export function publishDataset (peername = '', name = '', path = '') {
         method: 'POST',
         schema: Schemas.DATASET
       }
+    }).then(action => {
+      if (action.type === DATASET_PUBLISH_SUCCESS) {
+        // on successful save:
+        // remove all ids from registry pagination
+        dispatch(clearPagination('registryDatasets'))
+        // load registry datasets fresh
+        dispatch(loadRegistryDatasets())
+
+        return action
+      }
     })
   }
 }
@@ -378,6 +389,16 @@ export function unpublishDataset (peername = '', name = '', path = '') {
         endpoint: `/publish/${makeRef(peername, name, '', path)}`,
         method: 'DELETE',
         schema: Schemas.DATASET
+      }
+    }).then(action => {
+      if (action.type === DATASET_PUBLISH_SUCCESS) {
+        // on successful save:
+        // remove all ids from registry pagination
+        dispatch(clearPagination('registryDatasets'))
+        // load registry datasets fresh
+        dispatch(loadRegistryDatasets())
+
+        return action
       }
     })
   }

--- a/lib/actions/dataset.js
+++ b/lib/actions/dataset.js
@@ -9,6 +9,7 @@ import { selectDatasetByPath, selectDatasetByName } from '../selectors/dataset'
 import { selectSessionProfileId } from '../selectors/session'
 import { setMessage, resetMessage, clearPagination } from './app'
 import { setTransferStatus, removeTransferStatus } from './transfers'
+import { makeRef } from '../utils/ref'
 
 import {
   // DATASET_GET_BODY,
@@ -349,19 +350,19 @@ export function saveDataset (name = '', dataset = {}, transformScript = '', vizS
   }
 }
 
-export function togglePublishDataset (peername = '', name = '', published) {
+export function togglePublishDataset (peername = '', name = '', path = '', published) {
   return (dispatch) => {
     // TODO - should be getting dataset ref by name here
-    return dispatch(published ? unpublishDataset(peername, name) : publishDataset(peername, name))
+    return dispatch(published ? unpublishDataset(peername, name, path) : publishDataset(peername, name, path))
   }
 }
 
-export function publishDataset (peername = '', name = '') {
+export function publishDataset (peername = '', name = '', path = '') {
   return (dispatch) => {
     return dispatch({
       [CALL_API]: {
         types: [DATASET_PUBLISH_REQUEST, DATASET_PUBLISH_SUCCESS, DATASET_PUBLISH_FAILURE],
-        endpoint: `/publish/${peername}/${name}`,
+        endpoint: `/publish/${makeRef(peername, name, '', path)}`,
         method: 'POST',
         schema: Schemas.DATASET
       }
@@ -369,12 +370,12 @@ export function publishDataset (peername = '', name = '') {
   }
 }
 
-export function unpublishDataset (peername = '', name = '') {
+export function unpublishDataset (peername = '', name = '', path = '') {
   return (dispatch) => {
     return dispatch({
       [CALL_API]: {
         types: [DATASET_PUBLISH_REQUEST, DATASET_PUBLISH_SUCCESS, DATASET_PUBLISH_FAILURE],
-        endpoint: `/publish/${peername}/${name}`,
+        endpoint: `/publish/${makeRef(peername, name, '', path)}`,
         method: 'DELETE',
         schema: Schemas.DATASET
       }
@@ -417,12 +418,12 @@ export function runDatasetSearch (searchString, page = 1, pageSize = 50) {
   }
 }
 
-export function addDataset (peername, name, id) {
+export function addDataset (peername, name, profileID, path) {
   return (dispatch) => {
-    dispatch(setTransferStatus(id))
+    dispatch(setTransferStatus(path))
     var endpoint = `/add/${peername}/${name}`
-    if (id) {
-      endpoint += `/at${id}`
+    if (path) {
+      endpoint += `@${profileID}${path}`
     }
     return dispatch({
       [CALL_API]: {
@@ -433,13 +434,13 @@ export function addDataset (peername, name, id) {
       }
     }).then(action => {
       if (action.type === DATASET_ADD_SUCCESS) {
-        dispatch(removeTransferStatus(id))
+        dispatch(removeTransferStatus(path))
         dispatch(setMessage('Peer dataset added to your local datasets!'))
         setTimeout(() => {
           dispatch(resetMessage())
         }, 2500)
       } else {
-        setTransferStatus(id, -1)
+        setTransferStatus(path, -1)
       }
       return action
     })

--- a/lib/components/dataset/Commits.js
+++ b/lib/components/dataset/Commits.js
@@ -59,7 +59,7 @@ export default class Commits extends Base {
 
   template (css) {
     const { loading } = this.state
-    const { log, currentID, datasetRef } = this.props
+    const { log, currentID, datasetRef, registryVersion, fromRegistry } = this.props
 
     if (loading) {
       return (
@@ -75,13 +75,15 @@ export default class Commits extends Base {
           data={log}
           component={CommitItemContainer}
           onSelectItem={this.onSelectProfile}
-          emptyComponent={<CommitItemContainer data={datasetRef} currentID={currentID} index={0} />}
+          emptyComponent={<CommitItemContainer data={datasetRef} currentID={currentID} index={0} registryVersion={registryVersion} />}
           loading={this.props.loading}
           fetchedAll={this.props.fetchedAll}
           onClick={this.handleLoadNextPage}
           type='history'
           currentID={currentID}
+          registryVersion={registryVersion}
         />
+        {fromRegistry && <div className={css('noteWrap')}>Note: this dataset is from the registry, so it's history may be incomplete</div>}
       </div>
     )
   }
@@ -90,6 +92,9 @@ export default class Commits extends Base {
     return {
       wrap: {
         marginTop: 40
+      },
+      noteWrap: {
+        margin: '40px 20px'
       },
       searchBox: {
         display: 'inline-block',

--- a/lib/components/dataset/Commits.js
+++ b/lib/components/dataset/Commits.js
@@ -59,7 +59,7 @@ export default class Commits extends Base {
 
   template (css) {
     const { loading } = this.state
-    const { log, currentID } = this.props
+    const { log, currentID, datasetRef } = this.props
 
     if (loading) {
       return (
@@ -75,7 +75,7 @@ export default class Commits extends Base {
           data={log}
           component={CommitItemContainer}
           onSelectItem={this.onSelectProfile}
-          emptyComponent={<label>No History</label>}
+          emptyComponent={<CommitItemContainer data={datasetRef} currentID={currentID} index={0} />}
           loading={this.props.loading}
           fetchedAll={this.props.fetchedAll}
           onClick={this.handleLoadNextPage}

--- a/lib/components/dataset/Dataset.js
+++ b/lib/components/dataset/Dataset.js
@@ -142,7 +142,8 @@ export default class Dataset extends Base {
   handleAddDataset () {
     const { peername, name, sessionProfile, datasetRef } = this.props
     const { path } = datasetRef
-    this.props.addDataset(peername, name, path).then(() => {
+    const profileID = datasetRef && datasetRef.dataset && datasetRef.dataset.commit && datasetRef.dataset.commit.author && datasetRef.dataset.commit.author.id
+    this.props.addDataset(peername, name, profileID, path).then(() => {
       this.props.loadDatasets(sessionProfile)
     })
   }
@@ -229,7 +230,7 @@ export default class Dataset extends Base {
           onRemove={this.handleDeleteDataset}
           onAdd={this.handleAddDataset}
           onEdit={this.handleEditDataset}
-          onTogglePublish={() => { this.props.togglePublishDataset(peername, name, datasetRef.published) }}
+          onTogglePublish={() => { this.props.togglePublishDataset(peername, name, datasetRef.path, datasetRef.published) }}
           exportPath={this.handleDownloadDataset()}
         />
       </div>

--- a/lib/components/dataset/Dataset.js
+++ b/lib/components/dataset/Dataset.js
@@ -45,6 +45,7 @@ export default class Dataset extends Base {
     if (!path) {
       if (DATASET_DEBUG >= 1) { console.log('!path: \nabout to loadDatasetByName') }
       this.props.loadDatasetByName(peername, name)
+      this.props.loadRegistryDatasetByName(peername, name)
     } else if (!datasetRef || !bodypath || !schema) {
       if (DATASET_DEBUG >= 1) { console.log('!datasetRef || !bodypath || !schema: \nabout to loadDatasetByPath') }
       // this.props.loadDatasetByPath(path, peername, name, ['bodypath', 'structure.schema'])
@@ -70,6 +71,7 @@ export default class Dataset extends Base {
     if (peername !== nextProps.peername || name !== nextProps.name) {
       if (DATASET_DEBUG >= 1) { console.log('!nextProps.path || peername !== nextProps.peername || name !== nextProps.name: \n about to loadDatasetByName') }
       this.props.loadDatasetByName(nextProps.peername, nextProps.name)
+      this.props.loadRegistryDatasetByName(nextProps.peername, nextProps.name)
     } else if (this.props.path !== nextProps.path && (!nextProps.datasetRef || !nextProps.bodypath || !nextProps.schema)) {
       if (DATASET_DEBUG >= 1) { console.log('!nextProps.datasetRef || !nextProps.bodypath || !nextProps.schema: \nabout to loadDatasetByPath') }
       this.props.loadDatasetByPath(nextProps.path, ['bodypath', 'structure.schema'])
@@ -167,7 +169,8 @@ export default class Dataset extends Base {
       isLatestDataset,
       isLocal,
       fromRegistry,
-      isInNamespace } = this.props
+      isInNamespace,
+      registryVersion } = this.props
 
     if (!datasetRef) {
       return <Spinner large />
@@ -198,6 +201,7 @@ export default class Dataset extends Base {
           name={name}
           isLocal={isLocal}
           fromRegistry={fromRegistry}
+          registryVersion={registryVersion}
         />
         <DatasetRouter
           meta={meta}
@@ -220,6 +224,7 @@ export default class Dataset extends Base {
           name={name}
           transfering={transfering}
           loadingBody={loadingBody}
+          registryVersion={registryVersion}
 
           isLocal={isLocal}
           fromRegistry={fromRegistry}

--- a/lib/components/dataset/DatasetButtonGroup.js
+++ b/lib/components/dataset/DatasetButtonGroup.js
@@ -28,7 +28,7 @@ export default class DatasetButtonGroup extends Base {
     }
 
     const publishedText = published ? 'Unpublish' : 'Publish'
-    if (isLocal && isInNamespace && onPublish) {
+    if (isLocal && isInNamespace && isLatestDataset && onPublish) {
       buttons.push({ onClick: onPublish, text: publishedText })
     }
 

--- a/lib/components/dataset/DatasetRouter.js
+++ b/lib/components/dataset/DatasetRouter.js
@@ -123,7 +123,7 @@ class DatasetRouter extends Base {
         {/*  Route to Commit */}
         <Route
           path={`${path}/history`}
-          render={props => this.renderDatasetSection(css, <CommitsContainer {...props} peername={peername} name={name} />)}
+          render={props => this.renderDatasetSection(css, <CommitsContainer {...props} peername={peername} name={name} datasetRef={datasetRef} />)}
         />
         {/*  Route to Viz */}
         <Route

--- a/lib/components/dataset/DatasetRouter.js
+++ b/lib/components/dataset/DatasetRouter.js
@@ -86,7 +86,9 @@ class DatasetRouter extends Base {
       path,
       reload,
       loadingBody,
-      dataset
+      dataset,
+      fromRegistry,
+      registryVersion
     } = this.props
 
     // const pathname = this.props.location.pathname
@@ -123,7 +125,7 @@ class DatasetRouter extends Base {
         {/*  Route to Commit */}
         <Route
           path={`${path}/history`}
-          render={props => this.renderDatasetSection(css, <CommitsContainer {...props} peername={peername} name={name} datasetRef={datasetRef} />)}
+          render={props => this.renderDatasetSection(css, <CommitsContainer {...props} peername={peername} name={name} datasetRef={datasetRef} registryVersion={registryVersion} fromRegistry={fromRegistry} />)}
         />
         {/*  Route to Viz */}
         <Route
@@ -146,7 +148,7 @@ class DatasetRouter extends Base {
         {/*  Default to dataset summary */}
         <Route
           path={`${path}`}
-          render={props => this.renderDatasetSection(css, <Overview {...props} datasetRef={datasetRef} profile={profile} url={url} />)}
+          render={props => this.renderDatasetSection(css, <Overview {...props} datasetRef={datasetRef} profile={profile} url={url} registryVersion={registryVersion} />)}
         />
       </Switch>
     )

--- a/lib/components/dataset/Overview.js
+++ b/lib/components/dataset/Overview.js
@@ -128,7 +128,7 @@ export default class Overview extends Base {
   }
 
   template (css) {
-    const { datasetRef, profile } = this.props
+    const { datasetRef, profile, registryVersion } = this.props
 
     if (datasetRef === undefined || datasetRef.dataset === undefined) {
       return (<p>No overview found for this dataset.</p>)
@@ -157,7 +157,7 @@ export default class Overview extends Base {
         {/* structure && updated && this.renderTitle(css, 'Structure', 'structure') */}
         {structure && updated && <div className='border-top border-bottom'><StatsBar stats={this.stats(structure)} updated={updated} /></div>}
         {/* commit && this.renderTitle(css, 'Commit', 'commit') */}
-        {commit && <CommitItem data={datasetRef} profile={profile} index={0} /> }
+        {commit && <CommitItem data={datasetRef} profile={profile} index={0} registryVersion={registryVersion} /> }
         {structure && structure.schema && this.renderSchema(css, structure.schema)}
       </div>
     )

--- a/lib/components/item/CommitItem.js
+++ b/lib/components/item/CommitItem.js
@@ -10,7 +10,7 @@ import Base from '../Base'
 
 export default class CommitItem extends Base {
   template (css) {
-    const { data, index, currentID, profile } = this.props
+    const { data, index, currentID, profile, registryVersion } = this.props
     const commit = data.dataset ? data.dataset.commit : {}
     const path = data && data.path
     const peername = data && data.peername
@@ -32,6 +32,7 @@ export default class CommitItem extends Base {
           <Hash hash={path} noPrefix style={{ display: 'inline-block' }} />
           <Datestamp dateString={commit.timestamp} muted />
         </Link>
+        {registryVersion === path && <div className='icon-inline' style={{ marginLeft: 5 }} title='published version'>star</div>}
       </div>
     )
   }
@@ -55,7 +56,8 @@ export default class CommitItem extends Base {
       },
       wrap: {
         margin: 20,
-        display: 'flex'
+        display: 'flex',
+        alignItems: 'center'
       },
       photo: {
         display: 'inline-block'

--- a/lib/containers/Dataset.js
+++ b/lib/containers/Dataset.js
@@ -12,11 +12,12 @@ import {
 } from '../actions/dataset'
 
 import { editDataset } from '../actions/editor'
+import { loadRegistryDatasetByName } from '../actions/registry'
 
 import { selectDatasetByPath, selectDatasetIdByName, selectDatasetBody, selectNoDatasetBody, extractSchema, isLocalDataset } from '../selectors/dataset'
 import { selectError, selectIsFetching, selectPageCount, selectFetchedAll } from '../selectors/pagination'
 import { selectSessionProfileId, selectSessionProfileHandle } from '../selectors/session'
-import { isRegistryDataset } from '../selectors/registry'
+import { isRegistryDataset, selectRegistryDatasetIdByName } from '../selectors/registry'
 import { selectProfileByName } from '../selectors/profiles'
 import { selectLayoutMain } from '../selectors/layout'
 import { selectIsTransfering } from '../selectors/transfers'
@@ -66,6 +67,7 @@ const DatasetContainer = connect(
       goBack: ownProps.history.goBack,
       layoutMain: selectLayoutMain(state),
       viewMode: state.app.viewMode,
+      registryVersion: selectRegistryDatasetIdByName(state, peername, name),
 
       isLatestDataset,
       isInNamespace: sessionProfileHandle === peername,
@@ -84,7 +86,8 @@ const DatasetContainer = connect(
     loadDatasetByName,
     loadProfileByName,
     togglePublishDataset,
-    editDataset
+    editDataset,
+    loadRegistryDatasetByName
   }
 )(Dataset, 'Dataset')
 

--- a/lib/selectors/dataset.js
+++ b/lib/selectors/dataset.js
@@ -163,5 +163,10 @@ export function isLocalDataset (state, path) {
   if (!datasetIds) {
     return false
   }
-  return datasetIds.includes(path)
+  if (datasetIds.includes(path)) {
+    return true
+  }
+  const datasetRef = state && state.entities && state.entities.datasets && state.entities.datasets[path]
+  const profileID = datasetRef && datasetRef.dataset && datasetRef.dataset.commit && datasetRef.dataset.commit.author && datasetRef.dataset.commit.author.id
+  return profileID === sessionID
 }

--- a/lib/selectors/registry.js
+++ b/lib/selectors/registry.js
@@ -29,23 +29,12 @@ export function selectRegistryDatasetByPath (state, path) {
 
 export function selectRegistryDatasetByName (state, handle, name) {
   const { datasets } = state.entities
-  const commits = Object.keys(datasets).filter(id => {
-    return (datasets[id].peername === handle && datasets[id].name === name)
+  const ids = selectRegistryListIds(state)
+  const registryDatasetId = ids.filter(id => {
+    const ds = datasets[id]
+    return ds.peername === handle && ds.name === name
   })
-  function compareCommits (a, b) {
-    const timestampA = datasets[a].dataset.commit.timestamp
-    const timestampB = datasets[b].dataset.commit.timestamp
-
-    if (timestampB < timestampA) {
-      return -1
-    }
-    if (timestampA < timestampB) {
-      return 1
-    }
-    return 0
-  }
-  commits.sort(compareCommits)
-  const id = commits ? commits[0] : undefined
+  const id = registryDatasetId ? registryDatasetId[0] : undefined
   return id ? datasets[id] : undefined
 }
 

--- a/lib/utils/__tests__/ref.test.js
+++ b/lib/utils/__tests__/ref.test.js
@@ -1,0 +1,37 @@
+/* global describe, it, expect */
+import { makeRef } from '../ref'
+
+describe('makeRef', () => {
+  it('makes a ref from a peername and name', () => {
+    const ref = makeRef('peername', 'name')
+    expect(ref).toEqual('peername/name')
+  })
+  it('returns an empty string if nothing given', () => {
+    const ref = makeRef()
+    expect(ref).toEqual('')
+  })
+  it('returns an empty string if only name given', () => {
+    const ref = makeRef('', 'name')
+    expect(ref).toEqual('')
+  })
+  it('returns a ref with only the profileID if only the profileID given', () => {
+    const ref = makeRef('', '', 'profileID')
+    expect(ref).toEqual('@profileID')
+  })
+  it('returns a ref with only the profileID if only the profileID given', () => {
+    const ref = makeRef('', '', 'profileID')
+    expect(ref).toEqual('@profileID')
+  })
+  it('returns a ref with only the path if only the path given', () => {
+    const ref = makeRef('', '', '', 'path')
+    expect(ref).toEqual('@/path')
+  })
+  it('returns a full ref', () => {
+    const ref = makeRef('peername', 'name', 'profileID', 'path')
+    expect(ref).toEqual('peername/name@profileID/path')
+  })
+  it('returns the correct ref if all but profileID are given', () => {
+    const ref = makeRef('peername', 'name', '', 'path')
+    expect(ref).toEqual('peername/name@/path')
+  })
+})

--- a/lib/utils/links.js
+++ b/lib/utils/links.js
@@ -68,13 +68,11 @@ export function datasetLinks (dataset, fromRegistry, isLocal) {
       }
     )
   }
-  if (!fromRegistry) {
-    linkList.push(
-      {
-        name: 'History',
-        link: 'history'
-      }
-    )
-  }
+  linkList.push(
+    {
+      name: 'History',
+      link: 'history'
+    }
+  )
   return linkList
 }

--- a/lib/utils/ref.js
+++ b/lib/utils/ref.js
@@ -1,0 +1,19 @@
+export function makeRef (peername = '', name = '', profileID = '', path = '') {
+  var ref = ''
+  if (peername && name) {
+    ref += `${peername}/${name}`
+  }
+  if (profileID || path) {
+    ref += '@'
+    if (profileID) {
+      ref += profileID
+    }
+    if (path) {
+      if (path[0] !== '/') {
+        ref += '/'
+      }
+      ref += path
+    }
+  }
+  return ref
+}


### PR DESCRIPTION
requires qri-io/qri/pull/635

1) publish and unpublish only show up for the latest datasets
2) the history of a dataset will indicate which dataset is the version currently on the registry
3) after publishing and unpublishing, reset the registryDatasets pagination