### PR TITLE
tests(editor reducer): add tests to the editor reducer

### DIFF
--- a/lib/components/dataset/Dataset.js
+++ b/lib/components/dataset/Dataset.js
@@ -72,7 +72,8 @@ export default class Dataset extends Base {
       console.log('nextProps:')
       console.log(nextProps)
     }
-    const { peername, name, sessionProfile, bodypath } = this.props
+    const { peername, name, sessionProfile, bodypath, error } = this.props
+
     if (peername !== nextProps.peername || name !== nextProps.name) {
       if (DATASET_DEBUG >= 1) { console.log('!nextProps.path || peername !== nextProps.peername || name !== nextProps.name: \n about to loadDatasetByName') }
       this.props.loadDatasetByName(nextProps.peername, nextProps.name)
@@ -80,7 +81,7 @@ export default class Dataset extends Base {
     } else if (this.props.path !== nextProps.path && (!nextProps.datasetRef || !nextProps.bodypath || !nextProps.schema)) {
       if (DATASET_DEBUG >= 1) { console.log('!nextProps.datasetRef || !nextProps.bodypath || !nextProps.schema: \nabout to loadDatasetByPath') }
       this.props.loadDatasetByPath(nextProps.path, ['bodypath', 'structure.schema'])
-    } else if (sessionProfile && nextProps.bodypath && (bodypath !== nextProps.bodypath || (!nextProps.body && !nextProps.loadingBody))) {
+    } else if (sessionProfile && !error && nextProps.bodypath && (bodypath !== nextProps.bodypath || (!nextProps.body && !nextProps.loadingBody))) {
       if (DATASET_DEBUG >= 1) { console.log('sessionProfile && nextProps.bodypath !== bodypath: \nabout to loadDatasetBody') }
       this.props.loadDatasetBody(nextProps.path, nextProps.bodypath)
     } else if (this.props.peername !== nextProps.peername) {

--- a/lib/reducers/__tests__/editor.test.js
+++ b/lib/reducers/__tests__/editor.test.js
@@ -1,0 +1,453 @@
+/* global describe, it, expect */
+import { Reducer } from 'redux-testkit'
+import EditorReducer, { initialState } from '../editor'
+import {
+  EDITOR_INIT_DATASET,
+  EDITOR_SET_NAME,
+  EDITOR_SET_COMMIT,
+  EDITOR_SET_META,
+  EDITOR_SET_STRUCTURE,
+  EDITOR_SET_BODY,
+  EDITOR_UPDATE_BODY,
+  EDITOR_SET_VIZ,
+  EDITOR_SET_VIZ_SCRIPT,
+  EDITOR_SET_TRANSFORM,
+  EDITOR_SET_TRANSFORM_SCRIPT,
+  EDITOR_REMOVE_SECTION,
+  EDITOR_SET_SCHEMA,
+  EDITOR_SET_BODY_VIEW,
+  EDITOR_SET_COL_ORDER,
+  EDITOR_SET_ROW_ORDER,
+  EDITOR_SET_BODY_ERROR
+} from '../../constants/editor'
+
+import { generateMatchingSchemaAndBody } from '../../qri/generate'
+
+function assignSchemaToDataset (dataset, schema) {
+  if (!dataset) {
+    return { structure: schema }
+  }
+  return Object.assign({}, dataset, { structure: Object.assign({}, dataset.structure, { schema }) })
+}
+
+describe('Editor Reducer', () => {
+  var testBody = [[1, 2, 3]]
+  var testBodyString = JSON.stringify(testBody, null, 2)
+
+  var state = Object.assign({}, initialState, {
+    dirty: true,
+    name: 'test name',
+    body: testBodyString,
+    dataset: {
+      commit: { id: '1', title: 'title', message: 'message' },
+      meta: { title: 'dataset title', description: 'woo description' },
+      structure: { format: 'json' },
+      transform: 'yay transform',
+      viz: 'yay viz'
+    },
+    transformScript: 'yay transformScript',
+    vizScript: 'yay vizScript'
+  })
+
+  const gen = generateMatchingSchemaAndBody('table', undefined, state.body, undefined, undefined, undefined)
+  const dataset = assignSchemaToDataset(state.dataset, gen.schema)
+  var parsedState = Object.assign({}, state, { colOrder: gen.colOrder, rowOrder: gen.rowOrder, body: gen.body, dataset, bodyView: 'table' })
+
+  it('should have an initialState (@@INIT)', () => {
+    expect(EditorReducer(undefined, { type: '@@INIT' })).toEqual(initialState)
+  })
+
+  it('should handle EDITOR_INIT_DATASET with no body on an initial state', () => {
+    const action = {
+      type: EDITOR_INIT_DATASET
+    }
+    Reducer(EditorReducer).expect(action).toReturnState(initialState)
+  })
+
+  it('should handle EDITOR_INIT_DATASET with a body on an initial state', () => {
+    const action = {
+      type: EDITOR_INIT_DATASET,
+      body: testBody
+    }
+    Reducer(EditorReducer).expect(action).toReturnState(Object.assign({}, initialState, { body: testBodyString }))
+  })
+
+  it('should handle EDITOR_INIT_DATASET with no body on an existing state', () => {
+    const action = {
+      type: EDITOR_INIT_DATASET
+    }
+    Reducer(EditorReducer).withState(state).expect(action).toReturnState(initialState)
+  })
+
+  it('should handle EDITOR_INIT_DATASET with body on an existing state', () => {
+    const action = {
+      type: EDITOR_INIT_DATASET,
+      body: testBody
+    }
+    Reducer(EditorReducer).withState(state).expect(action).toReturnState(Object.assign({}, initialState, { body: testBodyString }))
+  })
+
+  it('should handle EDITOR_SET_BODY_VIEW on an initial state', () => {
+    const action = {
+      type: EDITOR_SET_BODY_VIEW,
+      view: 'table'
+    }
+    Reducer(EditorReducer).expect(action).toReturnState(Object.assign({}, initialState, { bodyView: 'table', bodyError: 'Table view is reserved for two dimentional data, the top level body must be an array.' }))
+  })
+
+  it('should handle EDITOR_SET_BODY_VIEW to table on an existing state with an unparsed but valid 2D body', () => {
+    const action = {
+      type: EDITOR_SET_BODY_VIEW,
+      view: 'table'
+    }
+    const gen = generateMatchingSchemaAndBody('table', undefined, state.body, undefined, undefined, undefined)
+    const dataset = assignSchemaToDataset(state.dataset, gen.schema)
+    const returnState = Object.assign({}, state, { colOrder: gen.colOrder, rowOrder: gen.rowOrder, body: gen.body, dataset, bodyView: 'table' })
+    Reducer(EditorReducer).withState(state).expect(action).toReturnState(returnState)
+  })
+
+  it('should handle EDITOR_SET_BODY_VIEW to json on an existing state with an parsed body', () => {
+    const action = {
+      type: EDITOR_SET_BODY_VIEW,
+      view: 'json'
+    }
+    const returnState = Object.assign({}, parsedState, { body: testBodyString, bodyView: 'json' })
+    Reducer(EditorReducer).withState(parsedState).expect(action).toReturnState(returnState)
+  })
+
+  it('should handle EDITOR_SET_BODY_VIEW to table on an existing state with an unparsed but UNVALID body', () => {
+    const action = {
+      type: EDITOR_SET_BODY_VIEW,
+      view: 'table'
+    }
+    const invalidBodyState = Object.assign({}, state, { body: 'invalid' })
+    const error = generateMatchingSchemaAndBody('table', undefined, invalidBodyState.body, undefined, undefined, undefined)
+    const returnState = Object.assign({}, invalidBodyState, { bodyView: 'table', bodyError: error })
+    Reducer(EditorReducer).withState(invalidBodyState).expect(action).toReturnState(returnState)
+  })
+
+  it('should handle EDITOR_SET_NAME on an initial state', () => {
+    var name = 'test'
+    const action = {
+      type: EDITOR_SET_NAME,
+      name: name
+    }
+    Reducer(EditorReducer).expect(action).toReturnState(Object.assign({}, initialState, { dirty: true, name }))
+  })
+
+  it('should handle EDITOR_SET_NAME on an existing state', () => {
+    var name = 'test'
+    const action = {
+      type: EDITOR_SET_NAME,
+      name: name
+    }
+    Reducer(EditorReducer).withState(state).expect(action).toReturnState(Object.assign({}, state, { dirty: true, name }))
+  })
+
+  it('should handle EDITOR_SET_COMMIT on an initial state', () => {
+    var commit = { id: 'yay', title: 'commit title', message: 'commit message' }
+    const action = {
+      type: EDITOR_SET_COMMIT,
+      commit
+    }
+    Reducer(EditorReducer).expect(action).toReturnState(Object.assign({}, initialState, { dirty: true, dataset: Object.assign({}, initialState.dataset, { commit }) }))
+  })
+
+  it('should handle EDITOR_SET_COMMIT on an existing state', () => {
+    var commit = { id: 'yay', title: 'commit title', message: 'commit message' }
+    const action = {
+      type: EDITOR_SET_COMMIT,
+      commit
+    }
+    Reducer(EditorReducer).withState(state).expect(action).toReturnState(Object.assign({}, state, { dirty: true, dataset: Object.assign({}, state.dataset, { commit }) }))
+  })
+
+  it('should handle EDITOR_SET_META on an initial state', () => {
+    var meta = { title: 'new meta' }
+    const action = {
+      type: EDITOR_SET_META,
+      meta
+    }
+    Reducer(EditorReducer).expect(action).toReturnState(Object.assign({}, initialState, { dirty: true, dataset: Object.assign({}, initialState.dataset, { meta }) }))
+  })
+
+  it('should handle EDITOR_SET_META on an existing state', () => {
+    var meta = { title: 'new meta' }
+    const action = {
+      type: EDITOR_SET_META,
+      meta
+    }
+    Reducer(EditorReducer).withState(state).expect(action).toReturnState(Object.assign({}, state, { dirty: true, dataset: Object.assign({}, state.dataset, { meta }) }))
+  })
+
+  it('should handle EDITOR_SET_STRUCTURE on an initial state', () => {
+    var structure = { format: 'csv' }
+    const action = {
+      type: EDITOR_SET_STRUCTURE,
+      structure
+    }
+    Reducer(EditorReducer).expect(action).toReturnState(Object.assign({}, initialState, { dirty: true, dataset: Object.assign({}, initialState.dataset, { structure }) }))
+  })
+
+  it('should handle EDITOR_SET_STRUCTURE on an existing state, staying as json', () => {
+    var structure = { format: 'csv' }
+    const action = {
+      type: EDITOR_SET_STRUCTURE,
+      structure
+    }
+    Reducer(EditorReducer).withState(state).expect(action).toReturnState(Object.assign({}, state, { dirty: true, dataset: Object.assign({}, state.dataset, { structure }) }))
+  })
+
+  it('should handle EDITOR_SET_SCHEMA on an initial state', () => {
+    var schema = { type: 'array' }
+    const action = {
+      type: EDITOR_SET_SCHEMA,
+      schema
+    }
+    Reducer(EditorReducer).expect(action).toReturnState(Object.assign({}, initialState, { dirty: true, dataset: assignSchemaToDataset(initialState.dataset, schema) }))
+  })
+
+  it('should handle EDITOR_SET_SCHEMA on an existing state', () => {
+    var schema = { type: 'array' }
+    const action = {
+      type: EDITOR_SET_SCHEMA,
+      schema
+    }
+    Reducer(EditorReducer).withState(state).expect(action).toReturnState(Object.assign({}, state, { dirty: true, dataset: assignSchemaToDataset(state.dataset, schema) }))
+  })
+
+  it('should handle EDITOR_SET_TRANSFORM on an initial state', () => {
+    var transform = { config: { url: 'http://www.yay.com' } }
+    const action = {
+      type: EDITOR_SET_TRANSFORM,
+      transform
+    }
+    Reducer(EditorReducer).expect(action).toReturnState(Object.assign({}, initialState, { dirty: true, dataset: Object.assign({}, initialState.dataset, { transform }) }))
+  })
+
+  it('should handle EDITOR_SET_TRANSFORM on an existing state', () => {
+    var transform = { config: { url: 'http://www.yay.com' } }
+    const action = {
+      type: EDITOR_SET_TRANSFORM,
+      transform
+    }
+    Reducer(EditorReducer).withState(state).expect(action).toReturnState(Object.assign({}, state, { dirty: true, dataset: Object.assign({}, state.dataset, { transform }) }))
+  })
+
+  it('should handle EDITOR_SET_VIZ on an initial state', () => {
+    var viz = { format: 'html' }
+    const action = {
+      type: EDITOR_SET_VIZ,
+      viz
+    }
+    Reducer(EditorReducer).expect(action).toReturnState(Object.assign({}, initialState, { dirty: true, dataset: Object.assign({}, initialState.dataset, { viz }) }))
+  })
+
+  it('should handle EDITOR_SET_VIZ on an existing state', () => {
+    var viz = { format: 'html' }
+    const action = {
+      type: EDITOR_SET_VIZ,
+      viz
+    }
+    Reducer(EditorReducer).withState(state).expect(action).toReturnState(Object.assign({}, state, { dirty: true, dataset: Object.assign({}, state.dataset, { viz }) }))
+  })
+
+  it('should handle EDITOR_SET_BODY on an initial state', () => {
+    var body = [ { first: 1 }, { second: 2 } ]
+    const action = {
+      type: EDITOR_SET_BODY,
+      body
+    }
+    Reducer(EditorReducer).expect(action).toReturnState(Object.assign({}, initialState, { dirty: true, body }))
+  })
+
+  it('should handle EDITOR_SET_BODY on an existing state', () => {
+    var body = [ { first: 1 }, { second: 2 } ]
+    const action = {
+      type: EDITOR_SET_BODY,
+      body
+    }
+    Reducer(EditorReducer).withState(state).expect(action).toReturnState(Object.assign({}, state, { dirty: true, body }))
+  })
+
+  it('should handle EDITOR_SET_BODY_ERROR on an initial state', () => {
+    var error = 'there was an error setting the body'
+    const action = {
+      type: EDITOR_SET_BODY_ERROR,
+      error
+    }
+    Reducer(EditorReducer).expect(action).toReturnState(Object.assign({}, initialState, { dirty: true, error }))
+  })
+
+  it('should handle EDITOR_SET_BODY_ERROR on an existing state', () => {
+    var error = 'there was an error setting the body'
+    const action = {
+      type: EDITOR_SET_BODY_ERROR,
+      error
+    }
+    Reducer(EditorReducer).withState(state).expect(action).toReturnState(Object.assign({}, state, { dirty: true, error }))
+  })
+
+  it('should handle EDITOR_UPDATE_BODY on an initial state', () => {
+    var changes = [[0, 0, 1, 10]]
+    const action = {
+      type: EDITOR_UPDATE_BODY,
+      changes
+    }
+    Reducer(EditorReducer).expect(action).toReturnState(Object.assign({}, initialState, { dirty: true, error: 'Attempting to make changes to an undefined body.' }))
+  })
+
+  it('should handle EDITOR_UPDATE_BODY on an existing state, where body is a string', () => {
+    var changes = [[0, 0, 1, 10]]
+    const action = {
+      type: EDITOR_UPDATE_BODY,
+      changes
+    }
+    Reducer(EditorReducer).withState(state).expect(action).toReturnState(Object.assign({}, state, { dirty: true, error: 'Body must be parsed and in table view in order to issue an update.' }))
+  })
+
+  it('should handle EDITOR_UPDATE_BODY on an existing state, where body is a 2D array', () => {
+    var changes = [[0, 0, 1, 10]]
+    const action = {
+      type: EDITOR_UPDATE_BODY,
+      changes
+    }
+    const returnState = Object.assign({}, parsedState, { body: [[10, 2, 3]] })
+    Reducer(EditorReducer).withState(parsedState).expect(action).toReturnState(returnState)
+  })
+
+  it('should handle EDITOR_SET_VIZ_SCRIPT on an initial state', () => {
+    var vizScript = '<html><body>hi!</body></html>'
+    const action = {
+      type: EDITOR_SET_VIZ_SCRIPT,
+      vizScript
+    }
+    Reducer(EditorReducer).expect(action).toReturnState(Object.assign({}, initialState, { dirty: true, vizScript }))
+  })
+
+  it('should handle EDITOR_SET_VIZ_SCRIPT on an existing state', () => {
+    var vizScript = '<html><body>hi!</body></html>'
+    const action = {
+      type: EDITOR_SET_VIZ_SCRIPT,
+      vizScript
+    }
+    Reducer(EditorReducer).withState(state).expect(action).toReturnState(Object.assign({}, state, { dirty: true, vizScript }))
+  })
+
+  it('should handle EDITOR_SET_TRANSFORM_SCRIPT on an initial state', () => {
+    var transformScript = 'def transform(ds, ctx):\n\tds.set_body([[1, 2, 3, 4]])'
+    const action = {
+      type: EDITOR_SET_TRANSFORM_SCRIPT,
+      transformScript
+    }
+    Reducer(EditorReducer).expect(action).toReturnState(Object.assign({}, initialState, { dirty: true, transformScript }))
+  })
+
+  it('should handle EDITOR_SET_TRANSFORM_SCRIPT on an existing state', () => {
+    var transformScript = 'def transform(ds, ctx):\n\tds.set_body([[1, 2, 3, 4]])'
+    const action = {
+      type: EDITOR_SET_TRANSFORM_SCRIPT,
+      transformScript
+    }
+    Reducer(EditorReducer).withState(state).expect(action).toReturnState(Object.assign({}, state, { dirty: true, transformScript }))
+  })
+
+  // EDITOR_REMOVE_SECTION
+  // should this be refactored to handle removing also the vizScript and vizTransform?
+  // remove: structure, transform, viz, commit, meta, body
+  it('should handle EDITOR_REMOVE_SECTION when trying to remove the structure of a dataset', () => {
+    const action = {
+      type: EDITOR_REMOVE_SECTION,
+      section: 'structure'
+    }
+    Reducer(EditorReducer).withState(state).expect(action).toReturnState(Object.assign({}, state, { dirty: true, dataset: Object.assign({}, state.dataset, { structure: undefined }) }))
+  })
+
+  it('should handle EDITOR_REMOVE_SECTION when trying to remove the transform of a dataset', () => {
+    const action = {
+      type: EDITOR_REMOVE_SECTION,
+      section: 'transform'
+    }
+    Reducer(EditorReducer).withState(state).expect(action).toReturnState(Object.assign({}, state, { dirty: true, dataset: Object.assign({}, state.dataset, { transform: undefined }) }))
+  })
+
+  it('should handle EDITOR_REMOVE_SECTION when trying to remove the viz of a dataset', () => {
+    const action = {
+      type: EDITOR_REMOVE_SECTION,
+      section: 'viz'
+    }
+    Reducer(EditorReducer).withState(state).expect(action).toReturnState(Object.assign({}, state, { dirty: true, dataset: Object.assign({}, state.dataset, { viz: undefined }) }))
+  })
+
+  it('should handle EDITOR_REMOVE_SECTION when trying to remove the commit of a dataset', () => {
+    const action = {
+      type: EDITOR_REMOVE_SECTION,
+      section: 'commit'
+    }
+    Reducer(EditorReducer).withState(state).expect(action).toReturnState(Object.assign({}, state, { dirty: true, dataset: Object.assign({}, state.dataset, { commit: undefined }) }))
+  })
+
+  it('should handle EDITOR_REMOVE_SECTION when trying to remove the meta of a dataset', () => {
+    const action = {
+      type: EDITOR_REMOVE_SECTION,
+      section: 'meta'
+    }
+    Reducer(EditorReducer).withState(state).expect(action).toReturnState(Object.assign({}, state, { dirty: true, dataset: Object.assign({}, state.dataset, { meta: undefined }) }))
+  })
+
+  it('should handle EDITOR_REMOVE_SECTION when trying to remove the body (stringify)', () => {
+    const action = {
+      type: EDITOR_REMOVE_SECTION,
+      section: 'body'
+    }
+    const bodyBytesState = Object.assign({}, state, { dataset: Object.assign({}, state.dataset, { bodyBytes: 'wooo bodyBytes!!!' }) })
+    Reducer(EditorReducer).withState(bodyBytesState).expect(action).toReturnState(Object.assign({}, state, { dirty: true, body: undefined, dataset: state.dataset }))
+  })
+
+  it('should handle EDITOR_REMOVE_SECTION when trying to remove the body (parsed)', () => {
+    const action = {
+      type: EDITOR_REMOVE_SECTION,
+      section: 'body'
+    }
+
+    const returnState = Object.assign({}, parsedState, { body: undefined, dirty: true, colOrder: undefined, rowOrder: undefined, bodyView: 'json' })
+
+    Reducer(EditorReducer).withState(parsedState).expect(action).toReturnState(returnState)
+  })
+
+  it('should handle EDITOR_SET_ROW_ORDER on an initial state', () => {
+    var order = [0, 1, 2, 3]
+    const action = {
+      type: EDITOR_SET_ROW_ORDER,
+      order
+    }
+    Reducer(EditorReducer).expect(action).toReturnState(Object.assign({}, initialState, { dirty: true, rowOrder: order }))
+  })
+
+  it('should handle EDITOR_SET_ROW_ORDER on an existing state', () => {
+    var order = [0, 1, 2, 3]
+    const action = {
+      type: EDITOR_SET_ROW_ORDER,
+      order
+    }
+    Reducer(EditorReducer).withState(state).expect(action).toReturnState(Object.assign({}, state, { dirty: true, rowOrder: order }))
+  })
+
+  it('should handle EDITOR_SET_COL_ORDER on an initial state', () => {
+    var order = [0, 1, 2, 3]
+    const action = {
+      type: EDITOR_SET_COL_ORDER,
+      order
+    }
+    Reducer(EditorReducer).expect(action).toReturnState(Object.assign({}, initialState, { dirty: true, colOrder: order }))
+  })
+
+  it('should handle EDITOR_SET_COL_ORDER on an existing state', () => {
+    var order = [0, 1, 2, 3]
+    const action = {
+      type: EDITOR_SET_COL_ORDER,
+      order
+    }
+    Reducer(EditorReducer).withState(state).expect(action).toReturnState(Object.assign({}, state, { dirty: true, colOrder: order }))
+  })
+})

--- a/lib/reducers/editor.js
+++ b/lib/reducers/editor.js
@@ -24,7 +24,7 @@ import {
 
 import cloneDeep from 'clone-deep'
 
-const initialState = {
+export const initialState = {
   dirty: false,
   name: '',
   dataset: {},
@@ -45,15 +45,7 @@ export default function editorReducer (state = initialState, action) {
       if (body) {
         body = JSON.stringify(action.body, null, 2)
       }
-      return {
-        dirty: false,
-        name: action.name || '',
-        dataset: action.dataset || {},
-        vizScript: action.vizScript,
-        transformScript: action.transformScript,
-        bodyView: 'json',
-        body: body
-      }
+      return Object.assign({}, initialState, { body })
     case EDITOR_SET_BODY_VIEW:
       var { body: prevBody, columnHeaders, colOrder, rowOrder, dirty } = state
       var dataset = state.dataset
@@ -102,21 +94,9 @@ export default function editorReducer (state = initialState, action) {
         dataset: Object.assign({}, state.dataset, { meta: action.meta })
       })
     case EDITOR_SET_STRUCTURE:
-      dataset = state.dataset
-      body = cloneDeep(state.body)
-      const prevFormat = state && state.dataset && state.dataset.structure && state.dataset.structure.format
-      const currFormat = action.structure && action.structure.format
-      if (prevFormat !== currFormat) {
-        // if we are flipping back to csv, we need to make sure that the body
-        // is not a string
-        if (currFormat === 'csv' && typeof body === 'string') {
-          body = JSON.parse(body)
-        }
-      }
       return Object.assign({}, state, {
         dirty: true,
-        dataset: Object.assign({}, state.dataset, { structure: action.structure }),
-        body
+        dataset: Object.assign({}, state.dataset, { structure: action.structure })
       })
     case EDITOR_SET_SCHEMA:
       dataset = state.dataset
@@ -138,6 +118,12 @@ export default function editorReducer (state = initialState, action) {
     case EDITOR_SET_BODY_ERROR:
       return Object.assign({}, state, { dirty: true, error: action.error })
     case EDITOR_UPDATE_BODY:
+      if (!state.body) {
+        return Object.assign({}, state, { dirty: true, error: 'Attempting to make changes to an undefined body.' })
+      }
+      if (typeof state.body === 'string') {
+        return Object.assign({}, state, { dirty: true, error: 'Body must be parsed and in table view in order to issue an update.' })
+      }
       var newBody = cloneDeep(state.body)
       for (let [row, column, oldValue, newValue] of action.changes) { // eslint-disable-line no-unused-vars
         newBody[row][column] = newValue

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "qri",
   "private": true,
   "productName": "qri",
-  "version": "0.7.0",
+  "version": "0.7.0-dev",
   "description": "qri (\"query\") frontend application",
   "keywords": [],
   "homepage": "https://qri.io",

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-export default '0.7.0'
+export default '0.7.1-dev'


### PR DESCRIPTION
Also fixes the error where the frontend bombards the backend with body requests, even if the body request returns an error.

 closes #451