### PR TITLE
fix(EditBody): fix bug that wasn't passing height to editor body

### DIFF
--- a/lib/components/editor/EditBody.js
+++ b/lib/components/editor/EditBody.js
@@ -319,7 +319,8 @@ export default class EditBody extends Base {
     const {
       body,
       bodyView,
-      columnHeaders
+      columnHeaders,
+      layout
     } = this.props
 
     const options = {
@@ -345,6 +346,7 @@ export default class EditBody extends Base {
             value={body}
             options={options}
             onChange={this.onMonacoChange}
+            height={layout.height - 100}
             // editorDidMount={this.editorDidMount}
           />
         )

--- a/lib/components/editor/Editor.js
+++ b/lib/components/editor/Editor.js
@@ -244,6 +244,7 @@ export default class Editor extends Base {
                     colOrder={colOrder}
                     bodyError={bodyError}
                     setBodyError={setBodyError}
+                    layout={layout}
                   />
                 )}
               />


### PR DESCRIPTION
missed a spot when I was updating the monaco editor stuff last week

need to pass the layout to the EditBody component, so we can figure out the height for the monaco editor.

Thanks @dustmop for finding this :)