### PR TITLE
fix(editor): Dataset name improvements after clicking 'Edit'

### DIFF
--- a/lib/components/form/ValidInput.js
+++ b/lib/components/form/ValidInput.js
@@ -14,7 +14,9 @@ export default class ValidInput extends Base {
     return (
       <div className={`${margin} validFormField form-group ${error && showError && 'has-error'} ${className} ${inline ? css('inline') : ''} `} style={width ? { width } : {}}>
         <div className='form-control-wrap-sm'>
+          <span style={{ 'position': 'relative', 'top': '0px' }}>me /&nbsp;</span>
           <input
+            style={{ 'display': 'inline-block' }}
             id={name}
             name={name}
             type={type}

--- a/lib/reducers/editor.js
+++ b/lib/reducers/editor.js
@@ -41,13 +41,20 @@ export const initialState = {
 export default function editorReducer (state = initialState, action) {
   switch (action.type) {
     case EDITOR_INIT_DATASET:
-      var body = action.body
-      if (body) {
-        body = JSON.stringify(action.body, null, 2)
+      let bodyText = action.body
+      if (action.body) {
+        bodyText = JSON.stringify(action.body, null, 2)
       }
-      return Object.assign({}, initialState, { body })
+      return Object.assign({}, initialState, {
+        name: action.name || '',
+        dataset: action.dataset || {},
+        body: bodyText,
+        vizScript: action.vizScript,
+        transformScript: action.transformScript
+      })
     case EDITOR_SET_BODY_VIEW:
-      var { body: prevBody, columnHeaders, colOrder, rowOrder, dirty } = state
+      var { body, columnHeaders, colOrder, rowOrder, dirty } = state
+      var prevBody = body
       var dataset = state.dataset
       const check = generateMatchingSchemaAndBody(action.view, dataset.structure, prevBody, columnHeaders, colOrder, rowOrder)
       if (typeof check === 'string') {


### PR DESCRIPTION
Two things:
* Show "me/" before the dataset name, to let the user know they only need to enter the name without peername
* Fill the dataset name, if it exists, into the dataset name field