### PR TITLE
fix(Transform): change case on import

### DIFF
--- a/lib/containers/Transform.js
+++ b/lib/containers/Transform.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux'
 
 import { selectCAFSString, selectCAFSLoading, selectCAFSError } from '../selectors/cafs'
 import { loadTransform } from '../actions/dataset'
-import Transform from '../components/dataset/transform'
+import Transform from '../components/dataset/Transform'
 
 const TransformContainer = connect(
   (state, ownProps) => {


### PR DESCRIPTION
Change the import of `../components/dataset/transform` to uppercase `Transform`
for case-sensitive systems (notice that the build was failing on my linux system and I suspect this is just a typo/oversight and not intentional).