### PR TITLE
refactor(*): first pass at turning class components into functional components

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qri-webapp",
   "productName": "qri",
-  "version": "0.7.2",
+  "version": "0.7.2-dev",
   "description": "qri (\"query\") frontend application",
   "main": "./main.prod.js",
   "author": {

--- a/lib/components/chrome/Button.js
+++ b/lib/components/chrome/Button.js
@@ -3,58 +3,71 @@ import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
 
 import Spinner from './Spinner'
-export default class Button extends React.PureComponent {
-  render () {
-    const { color, onClick, full, loading, attached, downloadName, disabled, download, float, link, type, text, large } = this.props
-    const className = 'btn btn-' + color
-    const size = large ? 'btn-large' : ''
 
-    var options = {}
-    options['className'] = `${className} ${full && 'button-full'} ${attached && 'button-attached'} ${float || ''} ${size}`
-    options['disabled'] = loading || disabled
-    options['onClick'] = onClick
-    options['type'] = type
+// Button is a the basic button used throughout the app
+const Button = ({ color,
+  onClick,
+  full,
+  loading,
+  attached,
+  downloadName,
+  disabled,
+  download,
+  float,
+  link,
+  type,
+  text,
+  large }) => {
+  const className = 'btn btn-' + color
+  const size = large ? 'btn-large' : ''
 
-    if (link) {
-      return (
-        <Link to={link}>
-          <button {...options}>
-            {loading ? <Spinner button center={false} white large={large} /> : text}
-          </button>
-        </Link>
-      )
-    }
+  var options = {}
+  options['className'] = `${className} ${full && 'button-full'} ${attached && 'button-attached'} ${float || ''} ${size}`
+  options['disabled'] = loading || disabled
+  options['onClick'] = onClick
+  options['type'] = type
 
-    if (download && downloadName) {
-      options['href'] = download
-      options['download'] = download ? `${downloadName}.zip` : undefined
-      return (
-        <a {...options}>
-          {loading ? <Spinner button center={false} white large={large} /> : text}
-        </a>
-      )
-    }
+  if (link) {
     return (
-      <button {...options}>
-        {loading ? <Spinner button center={false} white large={large} /> : text}
-      </button>
+      <Link to={link}>
+        <button {...options}>
+          {loading ? <Spinner button center={false} white large={large} /> : text}
+        </button>
+      </Link>
     )
   }
+
+  if (download && downloadName) {
+    options['href'] = download
+    options['download'] = download ? `${downloadName}.zip` : undefined
+    return (
+      <a {...options}>
+        {loading ? <Spinner button center={false} white large={large} /> : text}
+      </a>
+    )
+  }
+  return (
+    <button {...options}>
+      {loading ? <Spinner button center={false} white large={large} /> : text}
+    </button>
+  )
 }
 
 Button.propTypes = {
-  text: PropTypes.string.isRequired,
-  downloadName: PropTypes.string,
-  color: PropTypes.string,
-  onClick: PropTypes.func,
-  full: PropTypes.bool,
-  attached: PropTypes.bool,
-  loading: PropTypes.bool,
-  download: PropTypes.string,
-  link: PropTypes.string,
-  disabled: PropTypes.bool
+  text: PropTypes.string.isRequired, // the text written on the button
+  downloadName: PropTypes.string, // the name of the file that will be downloaded. Requires downloadName and download for the button to function properly
+  color: PropTypes.string, // the color of the button, default is 'primary'
+  onClick: PropTypes.func, // function that will trigger when the button is clicked
+  full: PropTypes.bool, // when full is true, the button has width 100%
+  attached: PropTypes.bool, // should only be true when the button is used by the dropdown component
+  loading: PropTypes.bool, // when true, the button is disabled and the loading spinner replaces the text
+  download: PropTypes.string, // the href of what you want to make available for download. Requires download and downloadName to function properly
+  link: PropTypes.string, // location that clicking the button will send you
+  disabled: PropTypes.bool // if true, the button is not clickable
 }
 
 Button.defaultProps = {
   color: 'primary'
 }
+
+export default Button

--- a/lib/components/chrome/Dropdown.js
+++ b/lib/components/chrome/Dropdown.js
@@ -1,74 +1,65 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import Button from './Button'
 
-export default class Dropdown extends React.PureComponent {
-  constructor (props) {
-    super(props)
-    this.state = {
-      display: false
-    };
-
-    [
-      'toggleMenu',
-      'onChooseOption'
-    ].forEach((m) => { this[m] = this[m].bind(this) })
+// Dropdown is a dropdown menu, made from a Qri button, a html button (with a carot) and a passed in dropdown component
+const Dropdown = ({ color, onClick, loading, text, download, disabled, options, downloadName, onChooseOption, DropdownMenu }) => {
+  const [display, setDisplay] = useState(false)
+  const onClickOption = (opt) => {
+    setDisplay(false)
+    onChooseOption(opt)
   }
+  const className = 'btn btn-' + color
 
-  toggleMenu () {
-    const display = this.state.display
-    this.setState({ display: !display })
-  }
-
-  onChooseOption (opt) {
-    this.setState({ display: false })
-    this.props.onChooseOption(opt)
-  }
-
-  render () {
-    const { color, onClick, loading, text, download, disabled, options } = this.props
-    const className = 'btn btn-' + color
-
-    const display = this.state.display
-
-    return (
-      <div className='dropdown dropdown-wrap'>
-        <div>
-          <Button
-            loading={loading}
-            onClick={onClick}
-            text={text}
-            color={color}
-            download={download}
-            disabled={disabled}
-            attached
-          />
-          <button
-            className={`icon-inline ${className} dropdown-caret dropdown-toggle`}
-            type='button'
-            onClick={() => this.toggleMenu()}
-          >
-            dropdown
-          </button>
-        </div>
-        <div>
-          <this.props.dropdown display={display} options={options} onChooseOption={this.onChooseOption} />
-        </div>
+  return (
+    <div className='dropdown dropdown-wrap'>
+      <div>
+        <Button
+          loading={loading}
+          onClick={onClick}
+          text={text}
+          color={color}
+          download={download}
+          downloadName={downloadName}
+          disabled={disabled}
+          attached
+        />
+        <button
+          className={`icon-inline ${className} dropdown-caret dropdown-toggle`}
+          type='button'
+          onClick={() => setDisplay(!display)}
+        >
+          dropdown
+        </button>
       </div>
-    )
-  }
+      <div>
+        <DropdownMenu display={display} options={options} onChooseOption={onClickOption} />
+      </div>
+    </div>
+  )
 }
 
 Dropdown.propTypes = {
+  // options: options to display in the dropdown menu
   options: PropTypes.array,
+  // onChooseOption: function that gets triggered when you choose an option (not when you click the button)
   onChooseOption: PropTypes.func,
+  // text: the text that is displayed on the dropdown button
   text: PropTypes.string.isRequired,
+  // color: the color of the button, default is 'primary'
   color: PropTypes.string,
+  // onClick: the function that fires when the dropdown button is clicked
   onClick: PropTypes.func,
+  // dropdown: the component that gets displayed when you show the dropdown menu
   dropdown: PropTypes.func,
-  download: PropTypes.string
+  // download: the href that would get passed down to the Button
+  download: PropTypes.string,
+  // downloadName: name that would get passed down to the Button
+  downloadName: PropTypes.string
 }
 
 Dropdown.defaultProps = {
   color: 'primary'
 }
+
+export default Dropdown

--- a/lib/components/chrome/DropdownMenu.js
+++ b/lib/components/chrome/DropdownMenu.js
@@ -1,17 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-export default class DropdownMenu extends React.PureComponent {
-  render () {
-    const { display, options, onChooseOption } = this.props
-    return (
-      <div className={`dropdown-menu ${display && 'dropdown-menu-block'}`}>
-        {options.map((opt, i) => {
-          return <a key={i} className='dropdown-item' onClick={onChooseOption.bind(this, opt)} >{opt}</a>
-        })}
-      </div>
-    )
-  }
+const DropdownMenu = ({ display, options, onChooseOption }) => {
+  return (
+    <div className={`dropdown-menu ${display && 'dropdown-menu-block'}`}>
+      {options.map((opt, i) => {
+        return <a key={i} className='dropdown-item' onClick={onChooseOption.bind(this, opt)} >{opt}</a>
+      })}
+    </div>
+  )
 }
 
 DropdownMenu.propTypes = {
@@ -24,3 +21,5 @@ DropdownMenu.defaultProps = {
   options: ['Action', 'Another Action', 'Something else here'],
   onChooseOption: (opt) => { console.log('chose option:', opt) }
 }
+
+export default DropdownMenu

--- a/lib/components/chrome/LoadMore.js
+++ b/lib/components/chrome/LoadMore.js
@@ -3,45 +3,25 @@ import PropTypes from 'prop-types'
 import Spinner from './Spinner'
 import Button from './Button'
 
-export default class LoadMore extends React.PureComponent {
-  constructor (props) {
-    super(props);
-    [
-      'renderLoadMore',
-      'renderEnd'
-    ].forEach((m) => { this[m] = this[m].bind(this) })
-  }
-
-  renderLoadMore (onClick) {
+const LoadMore = ({ fetchedAll, onClick, loading }) => {
+  if (loading) {
     return (
-      <Button color='primary' onClick={onClick} text='load more' />
+      <Spinner />
     )
   }
-
-  renderEnd (type) {
-    return (
-      <div className='load-more-end' />
-    )
-  }
-
-  render () {
-    const { fetchedAll, onClick, type, loading } = this.props
-    if (loading) {
-      return (
-        <Spinner />
-      )
-    }
-    return (
-      <div className='load-more-wrap'>
-        { fetchedAll ? this.renderEnd(type) : this.renderLoadMore(onClick) }
-      </div>
-    )
-  }
+  return (
+    <div className='load-more-wrap'>
+      { fetchedAll
+        ? <div className='load-more-end' />
+        : <Button color='primary' onClick={onClick} text='load more' /> }
+    </div>
+  )
 }
 
 LoadMore.propTypes = {
   loading: PropTypes.bool.isRequired,
   fetchedAll: PropTypes.bool.isRequired,
-  onClick: PropTypes.func.isRequired,
-  type: PropTypes.string.isRequired
+  onClick: PropTypes.func.isRequired
 }
+
+export default LoadMore

--- a/lib/components/chrome/NavLinks.js
+++ b/lib/components/chrome/NavLinks.js
@@ -1,40 +1,40 @@
 import React from 'react'
 import { NavLink } from 'react-router-dom'
 import PropTypes from 'prop-types'
-export default class NavLinks extends React.PureComponent {
-  render () {
-    const { url, linkList, sm } = this.props
 
-    // style based on sm or normal
-    const margin = sm ? 'nav-links-link-sm' : 'nav-links-link'
-    const marginRight = sm ? 10 : 15
-    const className = sm ? 'linkMediumMuted' : 'linkLargeMuted'
-    const activeClassName = sm ? 'linkMedium' : 'linkLarge'
-    return (
-      <div className='nav-links-wrap' >
-        {
-          linkList.map((item, index) => {
-            return (
-              <span
-                key={index}
-                id={item.name}
-                style={{ marginRight: index === 0 ? marginRight : undefined, opacity: (!item.active && item.faded) ? 0.2 : 1.0 }}
-                className={index === 0 ? '' : margin}>
-                <NavLink
-                  to={`${url === '/' ? '' : url}/${item.link}`}
-                  className={`${item.active ? activeClassName : className}`} >
-                  {item.name}
-                </NavLink>
-              </span>
-            )
-          })
-        }
-      </div>
-    )
-  }
+// NavLinks component is used in the Dataset and Editor to naviate around
+// the different sections of a Dataset
+const NavLinks = ({ url, linkList, sm }) => {
+  // style based on sm or normal
+  const margin = sm ? 'nav-links-link-sm' : 'nav-links-link'
+  const marginRight = sm ? 10 : 15
+  const className = sm ? 'linkMediumMuted' : 'linkLargeMuted'
+  const activeClassName = sm ? 'linkMedium' : 'linkLarge'
+  return (
+    <div className='nav-links-wrap' >
+      {
+        linkList.map((item, index) => {
+          return (
+            <span
+              key={index}
+              id={item.name}
+              style={{ marginRight: index === 0 ? marginRight : undefined, opacity: (!item.active && item.faded) ? 0.2 : 1.0 }}
+              className={index === 0 ? '' : margin}>
+              <NavLink
+                to={`${url === '/' ? '' : url}/${item.link}`}
+                className={`${item.active ? activeClassName : className}`} >
+                {item.name}
+              </NavLink>
+            </span>
+          )
+        })
+      }
+    </div>
+  )
 }
 
 NavLinks.propTypes = {
+  // linkList: array of objects that includes the link and the display name
   linkList: PropTypes.arrayOf(
     PropTypes.shape(
       {
@@ -43,6 +43,10 @@ NavLinks.propTypes = {
       }
     )
   ).isRequired,
+  // url: the base url that the link links to
   url: PropTypes.string.isRequired,
+  // sm: when sm is true, the NavLinks have a smaller formatting
   sm: PropTypes.bool
 }
+
+export default NavLinks

--- a/lib/components/chrome/Spinner.js
+++ b/lib/components/chrome/Spinner.js
@@ -1,27 +1,27 @@
 import React from 'react'
-
 import PropTypes from 'prop-types'
 
-export default class Spinner extends React.PureComponent {
-  render () {
-    const { center, button, white, large } = this.props
-    return (
-      <div className={`${button ? 'spinner-button' : 'spinner-spinner'} ${center && 'spinner-center'} ${!large && 'spinner-small'}`}>
-        <div className={`spinner-block spinner-rect1 ${white ? 'spinner-white' : 'spinner-dark'}`} />
-        <div className={`spinner-block spinner-rect2 ${white ? 'spinner-white' : 'spinner-dark'}`} />
-        <div className={`spinner-block spinner-rect3 ${white ? 'spinner-white' : 'spinner-dark'}`} />
-        <div className={`spinner-block spinner-rect4 ${white ? 'spinner-white' : 'spinner-dark'}`} />
-        <div className={`spinner-block spinner-rect5 ${white ? 'spinner-white' : 'spinner-dark'}`} />
-      </div>
-    )
-  }
+const Spinner = ({ center, button, white, large }) => {
+  return (
+    <div className={`${button ? 'spinner-button' : 'spinner-spinner'} ${center && 'spinner-center'} ${!large && 'spinner-small'}`}>
+      <div className={`spinner-block spinner-rect1 ${white ? 'spinner-white' : 'spinner-dark'}`} />
+      <div className={`spinner-block spinner-rect2 ${white ? 'spinner-white' : 'spinner-dark'}`} />
+      <div className={`spinner-block spinner-rect3 ${white ? 'spinner-white' : 'spinner-dark'}`} />
+      <div className={`spinner-block spinner-rect4 ${white ? 'spinner-white' : 'spinner-dark'}`} />
+      <div className={`spinner-block spinner-rect5 ${white ? 'spinner-white' : 'spinner-dark'}`} />
+    </div>
+  )
 }
 
 Spinner.propTypes = {
   button: PropTypes.bool,
-  center: PropTypes.bool.isRequired
+  center: PropTypes.bool.isRequired,
+  white: PropTypes.bool,
+  large: PropTypes.bool
 }
 
 Spinner.defaultProps = {
   center: true
 }
+
+export default Spinner

--- a/lib/components/item/CitationItem.js
+++ b/lib/components/item/CitationItem.js
@@ -2,34 +2,45 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import ValidInput from '../form/ValidInput'
 
-export default class CitationItem extends React.PureComponent {
-  constructor (props) {
-    super(props);
-
-    [
-      'handleChange'
-    ].forEach((m) => { this[m] = this[m].bind(this) })
-  }
-
-  handleChange (name, value, e) {
-    const { index, data, onChange } = this.props
+const CitationItem = ({ index, data, onChange, onRemove }) => {
+  const handleChange = (name, value, e) => {
     data[name] = value
     onChange(index, data)
   }
 
-  render () {
-    const { data, index, onRemove } = this.props
-    return (
-      <div className='citation-item-flex'>
-        <div className='citation-item-flex citation-item-inputs'>
-          <ValidInput name='name' label='name' value={data.name} placeholder='name' onChange={this.handleChange} inline width={'30%'} />
-          <ValidInput name='url' label='url' value={data.url} placeholder='url' onChange={this.handleChange} inline width={'30%'} />
-          <ValidInput name='email' label='email' value={data.email} placeholder='email' onChange={this.handleChange} inline width={'30%'} />
-        </div>
-        <a className='icon-inline citation-item-delete' onClick={() => onRemove(index)}>delete</a>
+  return (
+    <div className='citation-item-flex'>
+      <div className='citation-item-flex citation-item-inputs'>
+        <ValidInput
+          name='name'
+          label='name'
+          value={data.name}
+          placeholder='name'
+          onChange={handleChange}
+          inline width={'30%'}
+        />
+        <ValidInput
+          name='url'
+          label='url'
+          value={data.url}
+          placeholder='url'
+          onChange={handleChange}
+          inline
+          width={'30%'}
+        />
+        <ValidInput
+          name='email'
+          label='email'
+          value={data.email}
+          placeholder='email'
+          onChange={handleChange}
+          inline
+          width={'30%'}
+        />
       </div>
-    )
-  }
+      <a className='icon-inline citation-item-delete' onClick={() => onRemove(index)}>delete</a>
+    </div>
+  )
 }
 
 CitationItem.propTypes = {
@@ -40,3 +51,5 @@ CitationItem.propTypes = {
 
 CitationItem.defaultProps = {
 }
+
+export default CitationItem

--- a/lib/components/item/CommitItem.js
+++ b/lib/components/item/CommitItem.js
@@ -5,34 +5,32 @@ import { Link } from 'react-router-dom'
 import ProfilePhoto from '../profile/ProfilePhoto'
 import Hash from '../Hash'
 import Datestamp from '../Datestamp'
-export default class CommitItem extends React.PureComponent {
-  render () {
-    const { data, index, currentID, profile, registryVersion, sessionProfile } = this.props
-    const commit = data.dataset ? data.dataset.commit : {}
-    const path = data && data.path
-    const peername = data && data.peername
-    const name = data && data.name
-    const title = commit.title ? commit.title : `change #${index}`
-    const message = commit.message
-    const endpoint = `/${peername}/${name}/at${path}`
 
-    const info = currentID === path ? 'commit-item-info commit-info-no-click' : 'commit-item-info'
+const CommitItem = ({ data, index, currentID, profile, registryVersion, sessionProfile }) => {
+  const commit = data.dataset ? data.dataset.commit : {}
+  const path = data && data.path
+  const peername = data && data.peername
+  const name = data && data.name
+  const title = commit.title ? commit.title : `change #${index}`
+  const message = commit.message
+  const endpoint = `/${peername}/${name}/at${path}`
 
-    return (
-      <div className='commit-item-wrap' >
-        {sessionProfile ? <Link className='commit-item-photo' to={{ pathname: endpoint }}>
-          <ProfilePhoto profile={profile} />
-        </Link> : <ProfilePhoto profile={profile} /> }
-        <Link className={`${info} commit-item-color`} to={currentID === path ? {} : { pathname: endpoint }}>
-          <div className='commit-item-flex'><span className='commit-item-peername' >{peername}: </span><h5 className='commit-item-title'>{title || (index ? `commit #${index + 1}` : 'Current Dataset')}</h5></div>
-          {message && <span>{message}</span>}
-          <Hash hash={path} noPrefix style={{ display: 'inline-block' }} />
-          <Datestamp dateString={commit.timestamp} muted />
-        </Link>
-        {sessionProfile && registryVersion === path && <div className='icon-inline' style={{ marginLeft: 5 }} title='published version'>star</div>}
-      </div>
-    )
-  }
+  const info = currentID === path ? 'commit-item-info commit-info-no-click' : 'commit-item-info'
+
+  return (
+    <div className='commit-item-wrap' >
+      {sessionProfile ? <Link className='commit-item-photo' to={{ pathname: endpoint }}>
+        <ProfilePhoto profile={profile} />
+      </Link> : <ProfilePhoto profile={profile} /> }
+      <Link className={`${info} commit-item-color`} to={currentID === path ? {} : { pathname: endpoint }}>
+        <div className='commit-item-flex'><span className='commit-item-peername' >{peername}: </span><h5 className='commit-item-title'>{title || (index ? `commit #${index + 1}` : 'Current Dataset')}</h5></div>
+        {message && <span>{message}</span>}
+        <Hash hash={path} noPrefix style={{ display: 'inline-block' }} />
+        <Datestamp dateString={commit.timestamp} muted />
+      </Link>
+      {sessionProfile && registryVersion === path && <div className='icon-inline' style={{ marginLeft: 5 }} title='published version'>star</div>}
+    </div>
+  )
 }
 
 CommitItem.propTypes = {
@@ -42,3 +40,5 @@ CommitItem.propTypes = {
 
 CommitItem.defaultProps = {
 }
+
+export default CommitItem

--- a/lib/components/item/ContributorItem.js
+++ b/lib/components/item/ContributorItem.js
@@ -2,33 +2,45 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import ValidInput from '../form/ValidInput'
 
-export default class ContributorItem extends React.PureComponent {
-  constructor (props) {
-    super(props);
-
-    [
-      'handleChange'
-    ].forEach((m) => { this[m] = this[m].bind(this) })
-  }
-
-  handleChange (name, value, e) {
-    const { index, data, onChange } = this.props
+const ContributorItem = ({ index, data, onChange, onRemove }) => {
+  const handleChange = (name, value, e) => {
     onChange(index, Object.assign({}, data, { [name]: value }))
   }
 
-  render () {
-    const { data, index, onRemove } = this.props
-    return (
-      <div className='contributor-item-flex'>
-        <div className='contributor-item-flex contributor-item-inputs'>
-          <ValidInput name='id' label='id' value={data.id} placeholder='id' onChange={this.handleChange} inline width={'30%'} />
-          <ValidInput name='name' label='name' value={data.name} placeholder='name' onChange={this.handleChange} inline width={'30%'} />
-          <ValidInput name='email' label='email' value={data.email} placeholder='email' onChange={this.handleChange} inline width={'30%'} />
-        </div>
-        <a className='icon-inline contributor-item-delete' onClick={() => onRemove(index)}>delete</a>
+  return (
+    <div className='contributor-item-flex'>
+      <div className='contributor-item-flex contributor-item-inputs'>
+        <ValidInput
+          name='id'
+          label='id'
+          value={data.id}
+          placeholder='id'
+          onChange={handleChange}
+          inline
+          width={'30%'}
+        />
+        <ValidInput
+          name='name'
+          label='name'
+          value={data.name}
+          placeholder='name'
+          onChange={handleChange}
+          inline
+          width={'30%'}
+        />
+        <ValidInput
+          name='email'
+          label='email'
+          value={data.email}
+          placeholder='email'
+          onChange={handleChange}
+          inline
+          width={'30%'}
+        />
       </div>
-    )
-  }
+      <a className='icon-inline contributor-item-delete' onClick={() => onRemove(index)}>delete</a>
+    </div>
+  )
 }
 
 ContributorItem.propTypes = {
@@ -39,3 +51,5 @@ ContributorItem.propTypes = {
 
 ContributorItem.defaultProps = {
 }
+
+export default ContributorItem

--- a/lib/components/item/DatasetItem.js
+++ b/lib/components/item/DatasetItem.js
@@ -7,19 +7,9 @@ import DatasetName from '../DatasetName'
 
 import fileSize from '../../utils/filesize'
 
-export default class DatasetItem extends React.PureComponent {
-  constructor (props) {
-    super(props);
-
-    [
-      'titleString'
-    ].forEach((m) => { this[m] = this[m].bind(this) })
-  }
-
-  titleString () {
-    const { data = {}, small } = this.props
-    const name = data.name || ''
-    const { dataset = {} } = data
+const DatasetItem = ({ data = {}, small, rename, border, showPublishedStatus }) => {
+  // TODO (ramfox): pull out function so it can be reused elsewhere
+  const titleString = (name = '', dataset = {}) => {
     const { meta = {} } = dataset
     if (small && meta && meta.title && meta.title.length > 30) {
       return `${meta.title.slice(0, 30)}...`
@@ -27,7 +17,8 @@ export default class DatasetItem extends React.PureComponent {
     return (meta && meta.title) || name
   }
 
-  stats (datasetRef) {
+  // TODO (ramfox): pull out function so it can be reused elsewhere
+  const stats = (datasetRef) => {
     const { dataset } = datasetRef
 
     const length = dataset.structure.length
@@ -42,19 +33,32 @@ export default class DatasetItem extends React.PureComponent {
     ]
   }
 
-  render () {
-    const { data, rename, border, showPublishedStatus } = this.props
-    const title = this.titleString()
+  const title = titleString(data.name, data)
 
-    var path = `/${data.peername}/${data.name}/at${data.path}`
+  if (!data) {
     return (
-      <Link className={`dataset-item-wrap ${border && 'border-bottom '}`} to={{ pathname: path }} >
-        {title && <h3>{title}</h3>}
-        <DatasetName rename={rename} peername={data.peername} name={data.name || 'unnamed dataset'} style={{ display: 'inline-block', margin: '0 0 13px 0', wordWrap: 'break-word' }} />
-        { data.dataset && data.dataset.structure ? <StatsLine stats={this.stats(data)} updated={data.dataset && data.dataset.commit && data.dataset.commit.timestamp} published={showPublishedStatus && data.published} /> : undefined}
-      </Link>
+      <div>Error. No dataset information found.</div>
     )
   }
+
+  var path = `/${data.peername}/${data.name}/at${data.path}`
+  return (
+    <Link className={`dataset-item-wrap ${border && 'border-bottom '}`} to={{ pathname: path }} >
+      {title && <h3>{title}</h3>}
+      <DatasetName
+        rename={rename}
+        peername={data.peername}
+        name={data.name || 'unnamed dataset'}
+        style={{ display: 'inline-block', margin: '0 0 13px 0', wordWrap: 'break-word' }}
+      />
+      { data.dataset && data.dataset.structure
+        ? <StatsLine
+          stats={stats(data)}
+          updated={data.dataset && data.dataset.commit && data.dataset.commit.timestamp}
+          published={showPublishedStatus && data.published} />
+        : undefined}
+    </Link>
+  )
 }
 
 DatasetItem.propTypes = {
@@ -69,3 +73,5 @@ DatasetItem.propTypes = {
 DatasetItem.defaultProps = {
   small: false
 }
+
+export default DatasetItem

--- a/lib/components/item/FieldItem.js
+++ b/lib/components/item/FieldItem.js
@@ -18,20 +18,16 @@ function dataTypeColor (type, palette = defaultPalette) {
   }
 }
 
-export default class FieldItem extends React.PureComponent {
-  render () {
-    const { data, onSelect, index } = this.props
+const FieldItem = ({ data, onSelect, index }) => {
+  return (
+    <div className='field-item-wrap'>
+      <p className='field-item-datatype' style={{ color: dataTypeColor(data.type) }}><b className='field-item-index'>{index + 1}</b> {data.type}</p>
+      <h5 className='field-item-title' onClick={onSelect}>{data.name}</h5>
 
-    return (
-      <div className='field-item-wrap'>
-        <p className='field-item-datatype' style={{ color: dataTypeColor(data.type) }}><b className='field-item-index'>{index + 1}</b> {data.type}</p>
-        <h5 className='field-item-title' onClick={onSelect}>{data.name}</h5>
-
-        {data.missingValue && <p className='code muted'>default value: {data.missingValue}</p>}
-        {data.description && <p className='field-item-description'>{data.description}</p>}
-      </div>
-    )
-  }
+      {data.missingValue && <p className='code muted'>default value: {data.missingValue}</p>}
+      {data.description && <p className='field-item-description'>{data.description}</p>}
+    </div>
+  )
 }
 
 FieldItem.propTypes = {
@@ -41,3 +37,5 @@ FieldItem.propTypes = {
 
 FieldItem.defaultProps = {
 }
+
+export default FieldItem

--- a/lib/components/item/KeyValueItem.js
+++ b/lib/components/item/KeyValueItem.js
@@ -2,32 +2,36 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import ValidInput from '../form/ValidInput'
 
-export default class KeyValueItem extends React.PureComponent {
-  constructor (props) {
-    super(props);
-
-    [
-      'handleChange'
-    ].forEach((m) => { this[m] = this[m].bind(this) })
-  }
-
-  handleChange (name, value, e) {
-    const { index, data, onChange } = this.props
+const KeyValueItem = ({ index, data, onChange, onRemove }) => {
+  const handleChange = (name, value, e) => {
     onChange(index, Object.assign({}, data, { [name]: value }))
   }
 
-  render () {
-    const { data, index, onRemove } = this.props
-    return (
-      <div className='key-value-item-flex'>
-        <div className='key-value-item-flex key-value-item-inputs'>
-          <ValidInput name='key' label='key' value={data.key} placeholder='key' onChange={this.handleChange} inline width={200} />
-          <ValidInput name='value' label='value' value={data.value} placeholder='value' onChange={this.handleChange} inline width={200} />
-        </div>
-        <a className='icon-inline key-value-item-delete' onClick={() => onRemove(index)}>delete</a>
+  return (
+    <div className='key-value-item-flex'>
+      <div className='key-value-item-flex key-value-item-inputs'>
+        <ValidInput
+          name='key'
+          label='key'
+          value={data.key}
+          placeholder='key'
+          onChange={handleChange}
+          inline
+          width={200}
+        />
+        <ValidInput
+          name='value'
+          label='value'
+          value={data.value}
+          placeholder='value'
+          onChange={handleChange}
+          inline
+          width={200}
+        />
       </div>
-    )
-  }
+      <a className='icon-inline key-value-item-delete' onClick={() => onRemove(index)}>delete</a>
+    </div>
+  )
 }
 
 KeyValueItem.propTypes = {
@@ -38,3 +42,5 @@ KeyValueItem.propTypes = {
 
 KeyValueItem.defaultProps = {
 }
+
+export default KeyValueItem

--- a/lib/components/item/ProfileItem.js
+++ b/lib/components/item/ProfileItem.js
@@ -4,35 +4,32 @@ import { Link } from 'react-router-dom'
 
 import ProfilePhoto from '../profile/ProfilePhoto'
 import Online from '../Online'
-export default class ProfileItem extends React.PureComponent {
-  render () {
-    const { data, showStatus } = this.props
-
-    return (
-      <div className='sectionWidth profile-item-wrap' >
-        <Link className='profile-item-photo' to={{ pathname: `/${data.peername}` }}>
-          <ProfilePhoto profile={data} />
+const ProfileItem = ({ data, showStatus }) => {
+  return (
+    <div className='sectionWidth profile-item-wrap' >
+      <Link className='profile-item-photo' to={{ pathname: `/${data.peername}` }}>
+        <ProfilePhoto profile={data} />
+      </Link>
+      <div className='profile-item-info' >
+        { data.connected ? <b className='profile-item-name'> ⚡</b> : undefined }
+        <Link to={{ pathname: `/${data.peername}` }}>
+          <h3 className='profile-item-title'>{data.peername || 'unnamed peer'}</h3>
         </Link>
-        <div className='profile-item-info' >
-          { data.connected ? <b className='profile-item-name'> ⚡</b> : undefined }
-          <Link to={{ pathname: `/${data.peername}` }}>
-            <h3 className='profile-item-title'>{data.peername || 'unnamed peer'}</h3>
-          </Link>
-          {data.name && <p className='profile-item-muted profile-item-name'>{data.name}</p>}
-          {showStatus ? <Online online={data.online} small style={{ marginTop: 2 }} /> : undefined}
-        </div>
+        {data.name && <p className='profile-item-muted profile-item-name'>{data.name}</p>}
+        {showStatus ? <Online online={data.online} small style={{ marginTop: 2 }} /> : undefined}
       </div>
-    )
-  }
+    </div>
+  )
 }
 
 ProfileItem.propTypes = {
   data: PropTypes.object.isRequired,
   link: PropTypes.bool,
   showStatus: PropTypes.bool
-  // onSelect: PropTypes.func.isRequired
 }
 
 ProfileItem.defaultProps = {
   showStatus: true
 }
+
+export default ProfileItem

--- a/lib/components/item/SearchItem.js
+++ b/lib/components/item/SearchItem.js
@@ -4,48 +4,40 @@ import PropTypes from 'prop-types'
 import DatasetItem from './DatasetItem'
 import ProfileItem from './ProfileItem'
 
-export default class SearchItem extends React.PureComponent {
-  constructor (props) {
-    super(props);
-    [
-      'processDatasetResult',
-      'processProfileResult'
-    ].forEach((m) => { this[m] = this[m].bind(this) })
-  }
-
-  processDatasetResult (data) {
-    return {
-      peername: data['Value']['Handle'],
-      name: data['Value']['Name'],
-      path: data['Value']['path'],
-      dataset: {
-        meta: data['Value']['meta'],
-        structure: data['Value']['structure'],
-        commit: data['Value']['commit']
-      }
+const processDatasetResult = (data) => {
+  return {
+    peername: data['Value']['Handle'],
+    name: data['Value']['Name'],
+    path: data['Value']['path'],
+    dataset: {
+      meta: data['Value']['meta'],
+      structure: data['Value']['structure'],
+      commit: data['Value']['commit']
     }
   }
+}
 
-  processProfileResult (data) {
-    return data['Value']
-  }
+const processProfileResult = (data) => {
+  return data['Value']
+}
 
-  render () {
-    const { data } = this.props
+const SearchItem = (props) => {
+  const { data } = props
 
-    switch (data['Type']) {
-      case 'peer':
-        return <ProfileItem {...this.props} data={this.processProfileResult(data)} />
-      case 'dataset':
-      default:
-        return <DatasetItem {...this.props} data={this.processDatasetResult(data)} />
+  switch (data['Type']) {
+    case 'peer':
+      return <ProfileItem {...props} data={processProfileResult(data)} />
+    case 'dataset':
+    default:
+      return <DatasetItem {...props} data={processDatasetResult(data)} />
         // return <div>error: search result has no type. must be either 'dataset' or 'peer'</div>
         // the default should really be the above, but since the search responses have been returning
         // without a 'Type', I'm going to have the default return dataset
-    }
   }
 }
 
 SearchItem.propTypes = {
   data: PropTypes.object.isRequired
 }
+
+export default SearchItem

--- a/lib/components/item/StatItem.js
+++ b/lib/components/item/StatItem.js
@@ -1,19 +1,16 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-export default class StatItem extends React.PureComponent {
-  render () {
-    const { data: stat, style } = this.props
-    return (
-      <div className='stat-item-wrap' style={style} >
-        <div className='stat-item-icon-wrap'><span className='icon-inline' >{stat.icon}</span></div>
-        <div className='stat-item-text-wrap'>
-          <div><p className='stat-item-no-margin'>{stat.title}</p></div>
-          <h1 className='stat-item-no-margin'>{stat.stat}</h1>
-        </div>
+const StatItem = ({ data, style }) => {
+  return (
+    <div className='stat-item-wrap' style={style} >
+      <div className='stat-item-icon-wrap'><span className='icon-inline' >{data.icon}</span></div>
+      <div className='stat-item-text-wrap'>
+        <div><p className='stat-item-no-margin'>{data.title}</p></div>
+        <h1 className='stat-item-no-margin'>{data.stat}</h1>
       </div>
-    )
-  }
+    </div>
+  )
 }
 
 StatItem.propTypes = {
@@ -30,3 +27,5 @@ StatItem.defaultProps = {
   extraSpace: false,
   large: false
 }
+
+export default StatItem

--- a/lib/components/item/TagItem.js
+++ b/lib/components/item/TagItem.js
@@ -1,12 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-export default class TagItem extends React.PureComponent {
-  render () {
-    const { tag } = this.props
-
-    return (<div className='tag-item-pill'>{tag}</div>)
-  }
+const TagItem = ({ tag }) => {
+  return <div className='tag-item-pill'>{tag}</div>
 }
 
 TagItem.propTypes = {
@@ -16,5 +12,6 @@ TagItem.propTypes = {
 }
 
 TagItem.defaultProps = {
-  // color: 'a'
 }
+
+export default TagItem

--- a/lib/components/stylesheet/Stylesheet.js
+++ b/lib/components/stylesheet/Stylesheet.js
@@ -122,19 +122,11 @@ export default class Stylesheet extends React.PureComponent {
           </div>
         </div>
         <div>
-          <div className='stylesheet-button' ><Button text='a' color='a' name='a' /></div>
-          <div className='stylesheet-button' ><Button text='b' color='b' name='b' /></div>
-          <div className='stylesheet-button' ><Button text='c' color='c' name='' /></div>
-          <div className='stylesheet-button' ><Button text='d' color='d' name='d' /></div>
-          <div className='stylesheet-button' ><Button text='e' color='e' name='e' /></div>
-          <div className='stylesheet-button' ><Button text='f' color='f' name='f' /></div>
-          <div className='stylesheet-button' ><Button text='neutral-bold' color='neutral-bold' name='neutral-bold' /></div>
-          <div className='stylesheet-button' ><Button text='neutral' color='neutral' name='neutral' /></div>
-          <div className='stylesheet-button' ><Button text='neutral-muted' color='neutral-muted' name='neutral-muted' /></div>
+          <div className='stylesheet-button' ><Button text='primary'name='primary' /></div>
           <div className='stylesheet-button' ><Button text='dark' color='dark' name='dark' /></div>
-          <div className='stylesheet-button' ><Button text='loading' loading color='a' name='loading' /></div>
-          <div className='stylesheet-button' ><Button text='full width' full color='b' name='full' /></div>
-          <div className='stylesheet-button' style={{ width: 200, float: 'left' }}><Dropdown text='dropdown' color='e' name='dropdown' dropdown={DropdownMenu} /></div>
+          <div className='stylesheet-button' ><Button text='loading' loading name='loading' /></div>
+          <div className='stylesheet-button' ><Button text='full width' full name='full' /></div>
+          <div className='stylesheet-button' ><Dropdown text='dropdown' name='dropdown' DropdownMenu={DropdownMenu} options={['a', 'b', 'c']} /></div>
         </div>
         <div style={{ clear: 'both' }}>
           <div><RadioInput name='test' value='a' text='radio a' color='a' /></div>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "qri",
   "private": true,
   "productName": "qri",
-  "version": "0.7.1",
+  "version": "0.7.2-dev",
   "description": "qri (\"query\") frontend application",
   "keywords": [],
   "homepage": "https://qri.io",

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-export default '0.7.1'
+export default '0.7.2-dev'


### PR DESCRIPTION
- bumps version to 0.7.2-dev
- changes class components that do not use lifecycle components into functional components
  - item/CitationItem
  - item/ContributorItem
  - item/DatasetItem
  - item/FieldItem
  - item/KeyValueItem
  - item/ProfileItem
  - item/SearchItem
  - item/StatItem
  - item/TagItem
  - chrome/Button
  - chrome/Dropdown
  - chrome/DropdownMenu
  - chrome/NavLinks
  - chrome/Spinner
  - chrome/TopBar
- removes the app/dist contents, which should have been being ignored based on the .gitignore file
