### PR TITLE
feat(delete): adds ability to delete the most recent version of a dataset, not just the entire dataset history

### DIFF
--- a/lib/actions/body.js
+++ b/lib/actions/body.js
@@ -14,17 +14,23 @@ export function clearBody () {
   }
 }
 
-export function loadBody (path, bodypath, offset = 0, limit = 100) {
+export function loadBody (peername, name, path, bodypath, offset = 0, limit = 100) {
   return (dispatch, getState) => {
-    return dispatch(fetchBody(path, bodypath, offset, limit))
+    return dispatch(fetchBody(peername, name, path, bodypath, offset, limit))
   }
 }
 
-export function fetchBody (path, bodypath, offset = 0, limit = 100) {
+export function fetchBody (peername, name, path, bodypath, offset = 0, limit = 100) {
+  var endpoint
+  if (peername === '' || name === '') {
+    endpoint = `at${path}`
+  } else {
+    endpoint = `${peername}/${name}/at${path}`
+  }
   return {
     [CALL_API]: {
       types: [BODY_REQUEST, BODY_SUCCESS, BODY_FAILURE],
-      endpoint: `/body/at${path}`,
+      endpoint: `/body/${endpoint}`,
       schema: Schemas.STRUCTURED_DATA,
       data: { offset, limit, format: 'json' }
     },

--- a/lib/actions/dataset.js
+++ b/lib/actions/dataset.js
@@ -8,7 +8,7 @@ import Schemas from '../schemas'
 import { selectDatasetByPath, selectDatasetByName } from '../selectors/dataset'
 import { selectSessionProfileId } from '../selectors/session'
 import { loadRegistryDatasets } from './registry'
-import { setMessage, resetMessage, clearPagination } from './app'
+import { setMessage, resetMessage, clearPagination, clearPaginationIds } from './app'
 import { setTransferStatus, removeTransferStatus } from './transfers'
 import { makeRef } from '../utils/ref'
 
@@ -187,26 +187,36 @@ export function datasetRefToDatasetPod (datasetRef) {
   return datasetPod
 }
 
-export function deleteDataset (datasetRef) {
+export function deleteDataset (datasetRef, revisions = -1) {
   return (dispatch, getState) => {
     return dispatch({
       [CALL_API]: {
         types: [DATASET_DELETE_REQUEST, DATASET_DELETE_SUCCESS, DATASET_DELETE_FAILURE],
-        endpoint: `/remove/${datasetRef.peername}/${datasetRef.name}`,
+        endpoint: `/remove/${datasetRef.peername}/${datasetRef.name}?revisions=${revisions}`,
         method: 'DELETE',
         schema: Schemas.DATASET
-      }
+      },
+      revisions,
+      peername: datasetRef.peername,
+      name: datasetRef.name
     }).then((action) => {
       if (action.type === DATASET_DELETE_SUCCESS) {
         // on successful delete:
         // remove all ids from pagination
         dispatch(clearPagination('popularDatasets'))
+        // clear Pagination for history of this path
         // load datasets fresh
+        dispatch(clearPaginationIds('datasetHistory', `/${action.peername}/${action.name}`))
         const id = selectSessionProfileId(getState())
         dispatch(loadDatasets(id))
-
+        if (action.revisions === -1) {
         // and set a message with a timeout
-        dispatch(setMessage('dataset removed from your qri node'))
+          dispatch(setMessage('dataset removed from your qri node'))
+        } else if (action.revisions === 1) {
+          dispatch(setMessage('latest version of the dataset has been removed'))
+        } else {
+          dispatch(setMessage(`the ${action.revisions} most recent versions of the dataset have been removed`))
+        }
         setTimeout(() => {
           dispatch(resetMessage())
         }, 2500)

--- a/lib/actions/editor.js
+++ b/lib/actions/editor.js
@@ -92,8 +92,7 @@ export function editDataset (path) {
           resolve(nes)
           return
         }
-
-        dispatch(loadBody(nes.dataset.path, nes.dataset.bodyPath, 0, -1)).then((action) => {
+        dispatch(loadBody('me', nes.name, nes.dataset.path, nes.dataset.bodyPath, 0, -1)).then((action) => {
           nes.body = action.data
           resolve(nes)
         })

--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -177,7 +177,7 @@ export default class App extends React.PureComponent {
     }
 
     return (
-      <div className='alert sucess' role='alert'>
+      <div className='alert success' role='alert'>
         <div className='message'>{message}</div>
         <div className='dismiss'><a className='white icon-inline' onClick={this.handleDismissClick}>close</a></div>
       </div>

--- a/lib/components/dataset/Body.js
+++ b/lib/components/dataset/Body.js
@@ -32,7 +32,7 @@ const Body = (props) => {
     return schema && schema.map(i => i.title)
   }
 
-  const handleLoadMore = (limit) => { onLoadMore(path, bodypath, offset, limit) }
+  const handleLoadMore = (limit) => { onLoadMore(datasetRef.peername, datasetRef.name, path, bodypath, offset, limit) }
 
   if (__BUILD__.READONLY) {
     return (

--- a/lib/components/dataset/Dataset.js
+++ b/lib/components/dataset/Dataset.js
@@ -78,7 +78,7 @@ export default class Dataset extends React.PureComponent {
       //       })
       //   })
     } else if (sessionProfile && !body) {
-      this.props.loadBody(path, bodypath)
+      this.props.loadBody(peername, name, path, bodypath)
     } else if (!profile) {
       this.props.loadProfileByName(peername)
     }
@@ -126,15 +126,15 @@ export default class Dataset extends React.PureComponent {
             })
         })
     } else if (prevProps.sessionProfile && !prevProps.error && bodypath && (prevProps.bodypath !== bodypath || (!body && !bodyLoading))) {
-      this.props.loadBody(path, bodypath)
+      this.props.loadBody(peername, name, path, bodypath)
     } else if (prevProps.peername !== peername) {
       this.props.loadProfileByName(peername)
     }
   }
 
   handleReload () {
-    const { path, bodypath } = this.props
-    this.props.loadBody(path, bodypath)
+    const { peername, name, path, bodypath } = this.props
+    this.props.loadBody(peername, name, path, bodypath)
   }
 
   handleEditDataset () {

--- a/lib/components/dataset/DeleteDataset.js
+++ b/lib/components/dataset/DeleteDataset.js
@@ -8,28 +8,46 @@ export default class DeleteDataset extends React.PureComponent {
     const { datasetRef, onDelete, onCancel, history } = this.props
     return (
       <div className='white delete-dataset-wrap'>
-        <h1 className='white'>Delete Dataset</h1>
-        <p>Are you sure you want to delete dataset {datasetRef.peername}/{datasetRef.name}?</p>
-        <p>This action will remove all version of this dataset from your Qri node.</p>
-        <p>(Note: if this dataset has been published, the data may still exist on the network)</p>
-        <div className='delete-dataset-buttons'>
-          <Button
-            type='submit'
-            text='Delete'
-            onClick={() => {
-              onCancel()
-              onDelete(datasetRef)
-                .then((action) => {
-                  history.push('/')
-                })
-            }
-            }
-          />
-          <div className='delete-dataset-cancel'>
+        <div>
+          <h1 className='white'>Delete Most Recent</h1>
+          <p>Would you like to delete the most recent version of {datasetRef.peername}/{datasetRef.name}?</p>
+          <p>(Note: if this version of the dataset has been published, the data may still exist on the network)</p>
+          <div className='delete-dataset-buttons'>
+            <a onClick={onCancel} className='delete-dataset-cancel' >cancel</a>
             <Button
-              color='neutral-bold'
-              onClick={onCancel}
-              text='Cancel' />
+              type='submit'
+              text='DELETE ONE VERSION'
+              color='danger'
+              onClick={() => {
+                onCancel()
+                onDelete(datasetRef, 1)
+                  .then((action) => {
+                    history.push(`/${datasetRef.peername}/${datasetRef.name}`)
+                  })
+              }
+              }
+            />
+          </div>
+        </div>
+        <div className='delete-entire-dataset'>
+          <h3 className='white'>Delete Entire Dataset:</h3>
+          <p>If you want to delete the entire dataset, this cannot be undone!</p>
+          <p>(Note: if this dataset has been published, the data may still exist on the network)</p>
+          <div className='delete-dataset-buttons'>
+            <a onClick={onCancel} className='delete-dataset-cancel' >cancel</a>
+            <Button
+              type='submit'
+              text='DELETE ENTIRE DATASET'
+              color='danger'
+              onClick={() => {
+                onCancel()
+                onDelete(datasetRef, -1)
+                  .then((action) => {
+                    history.push('/')
+                  })
+              }
+              }
+            />
           </div>
         </div>
       </div>

--- a/lib/scss/_buttons.scss
+++ b/lib/scss/_buttons.scss
@@ -69,6 +69,10 @@ fieldset[disabled] a.btn {
   @include button-variant($white, $primary-dark, $primary-dark)
 }
 
+.btn-danger {
+  @include button-variant($white, $error, $error)
+}
+
 //
 // Link buttons
 //

--- a/lib/scss/_dataset.scss
+++ b/lib/scss/_dataset.scss
@@ -137,13 +137,26 @@
 }
 
 .delete-dataset-buttons {
-  float: right;
+  display: flex;
+  justify-content: space-between;
 }
 
 .delete-dataset-cancel {
+  color: #fff;
+  margin-top: 5px;
   margin-left: 10px;
-  display: inline-block;
 }
+
+.delete-entire-dataset {
+  padding-right: 20px;
+  position: absolute;
+  bottom: 10px;
+}
+
+.delete-entire-dataset-button {
+  margin-right: 20px;
+}
+
 
 ////////////////////////////
 //      ExportDataset     //


### PR DESCRIPTION
closes #478

This also fixes a bug I introduced when refactoring the body actions:

> Because of the way the qri backend canonicalizes the dataset (if there is no peername or name, it can only canonicalize references at head), we need to add the peername and name back into the `loadBody` action, to get correct responses when trying to get the body of a dataset that is not the most recent.