### PR TITLE
Use valid monospace font name

### DIFF
--- a/lib/scss/_site.scss
+++ b/lib/scss/_site.scss
@@ -297,7 +297,7 @@
 //          Json          //
 ////////////////////////////
 .json-text {
-  font-family: 'monospace';
+  font-family: monospace;
   font-size: 14px;
 }
 


### PR DESCRIPTION
Perhaps this should be `$font-family-monospace` instead. All I know is that `'monospace'` is not a valid font unless you have a font called `monospace` installed.
Before:
![image](https://user-images.githubusercontent.com/2925395/58646853-468f8800-82d4-11e9-98cc-630e5791ba0c.png)

After:
![image](https://user-images.githubusercontent.com/2925395/58646872-514a1d00-82d4-11e9-98cc-126490ccd84f.png)
