### PR TITLE
link and typo fixes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,10 +63,10 @@
 
 ## Contribute
 
-We've set up a separate document for our [contributor guildlines](https://github.com/qri-io/frontend/CONTRIBUTOR.md)!
+We've set up a separate document for our [contributor guidelines](https://github.com/qri-io/frontend/blob/master/CONTRIBUTOR.md)!
 
 ## Develop
 
-We've set up a separate document for [developer guildlines](https://github.com/qri-io/frontend/blob/master/DEVELOPER.md)!
+We've set up a separate document for [developer guidelines](https://github.com/qri-io/frontend/blob/master/DEVELOPER.md)!
 
 ###### This documentation has been adapted from the [Data Together](https://github.com/datatogether/datatogether), [Hyper](https://github.com/zeit/hyper), [AngularJS](https://github.com/angular/angularJS), and [Cycle.js](https://github.com/cyclejs/cyclejs) documentation.


### PR DESCRIPTION
previous link result:
![Screen Shot 2019-06-06 at 2 07 30 PM](https://user-images.githubusercontent.com/454690/59066763-a520ad00-8864-11e9-9c8e-677f4ad3a157.png)
