### PR TITLE
refactor(DownloadBar): add DownloadBar to dataset page in READONLY mode

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,5 +1,5 @@
 // adapted from https://storybook.js.org/docs/configurations/custom-webpack-config/
-
+const webpack = require('webpack')
 const path = require('path')
 
 //  Export a function. Accept the base config as the only param.
@@ -88,6 +88,11 @@ module.exports = async ({ config, mode }) => {
       test: /\.(?:ico|gif|png|jpg|jpeg|webp)$/,
       use: 'url-loader'
     })
+
+  config.plugins.push(
+    new webpack.NormalModuleReplacementPlugin(/(.*)\.APP_TARGET(\.*)/, function (resource) {
+      resource.request = resource.request.replace(/\.APP_TARGET/, '.web')
+    }))
 
   // Return the altered config
   return config

--- a/lib/components/chrome/DownloadBar.js
+++ b/lib/components/chrome/DownloadBar.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Button from './Button'
+
+import ExternalLink from '../ExternalLink.APP_TARGET'
+
+const DownloadBar = ({ layout, peername, name }) => {
+  // get layout from Dataset, assume height is same as topbar => 55px
+  return (
+    <div className='download-bar-wrap' style={layout} >
+      <ExternalLink href='https://qri.io/download' ><Button text='DOWNLOAD QRI' color='muted' /></ExternalLink>
+      <h5 className='download-bar-text'>to get the underlying data from </h5><h4 className='download-bar-dataset'>{peername}/{name}</h4>
+      <div className='download-bar-link'><ExternalLink href='https://qri.io/docs'>Need help?</ExternalLink></div>
+    </div>
+  )
+}
+
+DownloadBar.propTypes = {
+  layout: PropTypes.object.isRequired,
+  peername: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired
+}
+
+DownloadBar.defaultProps = {
+  layout: { height: 55, left: 0 }
+}
+
+export default DownloadBar

--- a/lib/components/chrome/DownloadBar.js
+++ b/lib/components/chrome/DownloadBar.js
@@ -13,7 +13,7 @@ const DownloadBar = ({ layout, peername, name }) => {
           <h5 className='download-bar-text'>to get the underlying data from </h5><h4 className='download-bar-dataset'>{peername}/{name}</h4>
         </ExternalLink>
       </div>
-      <div className='download-bar-link'><ExternalLink href='https://qri.io/docs'>Need help?</ExternalLink></div>
+      <div className='download-bar-link'><ExternalLink href='https://qri.io/docs/tutorials/frontend_get_data_from_app_to_desktop'>Need help?</ExternalLink></div>
     </div>
   )
 }

--- a/lib/components/chrome/DownloadBar.js
+++ b/lib/components/chrome/DownloadBar.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Button from './Button'
 
 import ExternalLink from '../ExternalLink.APP_TARGET'
 
@@ -8,8 +7,12 @@ const DownloadBar = ({ layout, peername, name }) => {
   // get layout from Dataset, assume height is same as topbar => 55px
   return (
     <div className='download-bar-wrap' style={layout} >
-      <ExternalLink href='https://qri.io/download' ><Button text='DOWNLOAD QRI' color='muted' /></ExternalLink>
-      <h5 className='download-bar-text'>to get the underlying data from </h5><h4 className='download-bar-dataset'>{peername}/{name}</h4>
+      <div className='download-bar-text-wrap'>
+        <ExternalLink href='https://qri.io/download' >
+          <h4 className='download-bar-dataset'>DOWNLOAD QRI HERE</h4>
+          <h5 className='download-bar-text'>to get the underlying data from </h5><h4 className='download-bar-dataset'>{peername}/{name}</h4>
+        </ExternalLink>
+      </div>
       <div className='download-bar-link'><ExternalLink href='https://qri.io/docs'>Need help?</ExternalLink></div>
     </div>
   )

--- a/lib/components/dataset/Dataset.js
+++ b/lib/components/dataset/Dataset.js
@@ -1,3 +1,4 @@
+/* globals __BUILD__ */
 import React from 'react'
 import PropTypes from 'prop-types'
 
@@ -11,6 +12,8 @@ import Spinner from '../chrome/Spinner'
 import history from '../../history'
 
 import { DATASET_UPDATE_SUCCESS } from '../../constants/dataset'
+
+const DownloadBar = React.lazy(() => import('../chrome/DownloadBar.js'))
 const DELETE_DATASET_MODAL = 'DELETE_DATASET_MODAL'
 const RENAME_DATASET_MODAL = 'RENAME_DATASET_MODAL'
 const EXPORT_DATASET_MODAL = 'EXPORT_DATASET_MODAL'
@@ -277,9 +280,17 @@ export default class Dataset extends React.PureComponent {
 
     // adjust layout to include dataset header size:
     var layout = Object.assign({}, layoutMain, { height: layoutMain.height - 140 })
+    // if in readonly mode, adjust the layout to include the DownloadBar:
+    if (__BUILD__.READONLY) {
+      layout = Object.assign({}, layout, { height: layout.height - 55 })
+      var downloadBarLayout = Object.assign({}, layout, { height: 55, top: 0 })
+    }
 
     return (
       <div className='dataset-wrap' >
+        {__BUILD__.READONLY &&
+          <DownloadBar peername={peername} name={name} layout={downloadBarLayout} />
+        }
         <DatasetHeader
           url={match.url}
           datasetRef={datasetRef}

--- a/lib/scss/_buttons.scss
+++ b/lib/scss/_buttons.scss
@@ -73,6 +73,9 @@ fieldset[disabled] a.btn {
   @include button-variant($white, $error, $error)
 }
 
+.btn-muted {
+  @include button-variant($black, $white, $primary-muted)
+}
 //
 // Link buttons
 //

--- a/lib/scss/_chrome.scss
+++ b/lib/scss/_chrome.scss
@@ -2,6 +2,7 @@
 // SCSS for Chrome components
 // 
 // Button
+// DownloadBar
 // Dropdown
 // DropdownMenu
 // LoadMore
@@ -18,6 +19,93 @@
 .button-attached {
   border-radius: 3px 0 0 3px;
 }
+
+////////////////////////////
+//       DownloadBar      //
+////////////////////////////
+.download-bar-wrap {
+  position: absolute;
+  overflow: hidden;
+  background: $primary-dark;
+  z-index: 1;
+  box-shadow: 0 0px 4px rgba(0, 0, 0, 0.35);
+  -webkit-app-region: drag;
+  display: flex;
+  width: 100%;
+  flex-wrap: wrap;
+  align-items: center;
+  padding-left: 10px;
+}
+
+.download-bar-text {
+  color: $sink;
+  margin: 3px 5px 0 5px;
+  display: flex;
+}
+
+.download-bar-dataset {
+  color: $white;
+  margin-top: 12px;
+  font-weight: $font-weight-medium;
+  // margin: 0 5px;
+}
+
+.download-bar-link {
+  margin-left: auto;
+  margin-right: 10px;
+}
+
+.download-bar-link > a {
+  color: $white;
+  &:hover {
+    color: $primary;
+  }
+}
+
+// .top-bar-title-bar {
+//   flex: 1 0 100%;
+//   width: 100%;
+//   height: 20px;
+//   text-align: center;
+// }
+
+// .top-bar-first-item {
+//   margin-right: 10;
+//   margin-left: 0;
+// }
+
+// .top-bar-item-spacing {
+//   margin-right: 30px;
+//   display: inline-block;
+// }
+
+// .top-bar-no-shrink {
+//   flex: 1 0;
+//   align-items: baseline;
+//   padding: 11px 0 0 20px;
+// }
+
+// .top-bar-help {
+//   display: flex;
+//   justify-content: flex-end;
+//   align-items: baseline;
+//   flex: 1 1;
+// }
+
+// .top-bar-current {
+//   color: $primary;
+// }
+
+// .top-bar-nav-button {
+//   font-family: SSPika;
+//   display: inline-block;
+//   text-align: center;
+//   width: 22px;
+//   height: 30px;
+//   font-size: 19px;
+//   color: $text;
+// }
+
 
 ////////////////////////////
 //        Dropdown        //

--- a/lib/scss/_chrome.scss
+++ b/lib/scss/_chrome.scss
@@ -24,7 +24,6 @@
 //       DownloadBar      //
 ////////////////////////////
 .download-bar-wrap {
-  position: absolute;
   overflow: hidden;
   background: $primary-dark;
   z-index: 1;
@@ -35,10 +34,16 @@
   flex-wrap: wrap;
   align-items: center;
   padding-left: 10px;
+  justify-content: center;
+}
+
+.download-bar-text-wrap > a {
+  display: flex;
+  align-items: center;
 }
 
 .download-bar-text {
-  color: $sink;
+  color: $white;
   margin: 3px 5px 0 5px;
   display: flex;
 }
@@ -47,12 +52,11 @@
   color: $white;
   margin-top: 12px;
   font-weight: $font-weight-medium;
-  // margin: 0 5px;
 }
 
 .download-bar-link {
-  margin-left: auto;
-  margin-right: 10px;
+  position: absolute;
+  right: 10px;
 }
 
 .download-bar-link > a {

--- a/stories/index.js
+++ b/stories/index.js
@@ -2,8 +2,14 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import Button from '../lib/components/chrome/Button.js'
+import DownloadBar from '../lib/components/chrome/DownloadBar.js'
+
+// Don't forget to import our stylesheet:
 import '../lib/app.global.scss'
 
 storiesOf('Button', module)
   .add('with text', () => <Button onClick={action('clicked')} text='qri button' />)
   .add('loading', () => <Button loading text='loading button' />)
+
+storiesOf('Download bar', module)
+  .add('standard', () => <DownloadBar layout={{ height: 55, top: 0, left: 0 }} peername='test_peer' name='test_dataset' />)


### PR DESCRIPTION
- adds DownloadBar to dataset page in READONLY mode
- adds DownloadBar to storybook
- adds webpack plugin to deal with `APP_TARGET` 

partially closes #501 (fully closed when a tutorial goes up and the DownloadBar links to the tutorial)