### PR TITLE
add tooltips to menu glyphs

### DIFF
--- a/lib/components/chrome/TopBar.js
+++ b/lib/components/chrome/TopBar.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
+import ReactTooltip from 'react-tooltip'
 
 import SearchBar from '../form/SearchBar'
 import ProfilePhoto from '../profile/ProfilePhoto'
@@ -32,6 +33,8 @@ export default class TopBar extends React.PureComponent {
     if (prevLocation.pathname !== location.pathname && location.pathname !== '/search') {
       this.props.setLocationBarText(location.pathname)
     }
+
+    ReactTooltip.rebuild()
   }
 
   handleGoBack () {
@@ -80,17 +83,18 @@ export default class TopBar extends React.PureComponent {
             <a className='top-bar-nav-button top-bar-first-item' onClick={this.handleGoBack}>left</a>
             <a className='top-bar-nav-button' onClick={this.handleGoForward}>right</a>
           </div>}
-          {sessionProfile && <Link className={`top-bar-nav-button top-bar-item-spacing ${current('/collection')}`} to='/collection'>layers</Link>}
-          <Link className={`top-bar-nav-button top-bar-item-spacing ${current('/network')}`} to='/network'>usergroup</Link>
+          {sessionProfile && <Link className={`top-bar-nav-button top-bar-item-spacing ${current('/collection')}`} to='/collection' data-tip='collection'>layers</Link>}
+          <Link className={`top-bar-nav-button top-bar-item-spacing ${current('/network')}`} to='/network' data-tip='network'>usergroup</Link>
           {(sessionProfile && !__BUILD__.READONLY) &&
-          <Link className={`top-bar-nav-button top-bar-item-spacing ${current('/edit')}`} to='/edit'>edit</Link>}
+          <Link className={`top-bar-nav-button top-bar-item-spacing ${current('/edit')}`} to='/edit' data-tip='edit'>edit</Link>}
         </div>
         <SearchBar onKeyUp={this.handleSearch} searchString={searchString} onChange={this.handleChange} />
         <div className='top-bar-help'>
-          <ExternalLink href='https://discord.gg/etap8Gb' className='top-bar-nav-button top-bar-item-spacing' target='_blank'>chat</ExternalLink>
-          <ExternalLink href='https://qri.io/docs' className='top-bar-nav-button top-bar-item-spacing' target='_blank'>help</ExternalLink>
-          {sessionProfile && <Link className='top-bar-nav-button top-bar-item-spacing' to='/profile'><ProfilePhoto profile={profile} size='sm' /></Link>}
+          <ExternalLink href='https://discord.gg/etap8Gb' className='top-bar-nav-button top-bar-item-spacing' target='_blank' data-tip='discord'>chat</ExternalLink>
+          <ExternalLink href='https://qri.io/docs' className='top-bar-nav-button top-bar-item-spacing' target='_blank' data-tip='documentation'>help</ExternalLink>
+          {sessionProfile && <Link className='top-bar-nav-button top-bar-item-spacing' to='/profile' data-tip='profile'><ProfilePhoto profile={profile} size='sm' /></Link>}
         </div>
+        <ReactTooltip place='bottom' type='dark' effect='solid' delayShow='1000' />
       </div>
     )
   }

--- a/lib/components/chrome/TopBar.js
+++ b/lib/components/chrome/TopBar.js
@@ -80,8 +80,8 @@ export default class TopBar extends React.PureComponent {
         </div>}
         <div className='top-bar-no-shrink'>
           {__BUILD__.ELECTRON && <div className='top-bar-item-spacing'>
-            <a className='top-bar-nav-button top-bar-first-item' onClick={this.handleGoBack}>left</a>
-            <a className='top-bar-nav-button' onClick={this.handleGoForward}>right</a>
+            <a className='top-bar-nav-button top-bar-first-item' onClick={this.handleGoBack} data-tip='forward'>left</a>
+            <a className='top-bar-nav-button' onClick={this.handleGoForward} data-tip='back'>right</a>
           </div>}
           {sessionProfile && <Link className={`top-bar-nav-button top-bar-item-spacing ${current('/collection')}`} to='/collection' data-tip='collection'>layers</Link>}
           <Link className={`top-bar-nav-button top-bar-item-spacing ${current('/network')}`} to='/network' data-tip='network'>usergroup</Link>

--- a/package.json
+++ b/package.json
@@ -236,6 +236,7 @@
     "react-router": "5.0.0",
     "react-router-dom": "5.0.0",
     "react-router-redux": "4.0.8",
+    "react-tooltip": "^3.10.0",
     "redux": "4.0.1",
     "redux-logger": "3.0.6",
     "redux-testkit": "1.0.6",
@@ -261,8 +262,8 @@
     "yarn": ">=0.21.3"
   },
   "devDependencies": {
-    "fetch-mock": "7.3.3",
     "@storybook/react": "5.0.11",
+    "fetch-mock": "7.3.3",
     "redux-mock-store": "1.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -236,7 +236,7 @@
     "react-router": "5.0.0",
     "react-router-dom": "5.0.0",
     "react-router-redux": "4.0.8",
-    "react-tooltip": "^3.10.0",
+    "react-tooltip": "3.10.0",
     "redux": "4.0.1",
     "redux-logger": "3.0.6",
     "redux-testkit": "1.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12376,6 +12376,14 @@ react-textarea-autosize@^7.0.4:
     "@babel/runtime" "^7.1.2"
     prop-types "^15.6.0"
 
+react-tooltip@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-3.10.0.tgz#268b5ef519fd8a1369288d1f086f42c90d5da7ef"
+  integrity sha512-GGdxJvM1zSFztkTP7gCQbLTstWr1OOoMpJ5WZUGhimj0nhRY+MPz+92MpEnKmj0cftJ9Pd/M6FfSl0sfzmZWkg==
+  dependencies:
+    classnames "^2.2.5"
+    prop-types "^15.6.0"
+
 react-transform-catch-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/react-transform-catch-errors/-/react-transform-catch-errors-1.0.2.tgz#1b4d4a76e97271896fc16fe3086c793ec88a9eeb"


### PR DESCRIPTION
This PR adds `react-tooltip` and implements simple tooltips for each glyph in the top bar.  Tooltips are delayed, and show up after the user hovers for 1000ms.

<img width="402" alt="Fullscreen_7_1_19__10_56_PM" src="https://user-images.githubusercontent.com/1833820/60479366-9bb41600-9c53-11e9-9972-b3bbb98df6d0.png">
